### PR TITLE
Allow specifying custom YSQL/YCQL/YEDIS ports

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -332,11 +332,11 @@ def remove_surrounding_quotes(s):
 
 
 class Installer:
-    YUGABYTE_DB_VERSION = '1.2.10.0'
+    YUGABYTE_DB_VERSION = '1.2.11.0'
     DOWNLOAD_URL_PATTERN = 'https://downloads.yugabyte.com/yugabyte-ce-{version}-{os}.tar.gz'
     SHA256_SUM_BY_OS = {
-        'darwin': 'ee5ba828b0b702016c4a6003cc4f3bda3eee0e0ffbb954dd409d55fde7687d97',
-        'linux': '34f0426f1d0b9d61a8cf72c3328c9d3a538f5c8267669c0e02b780b124b9e75b'
+        'darwin': 'acb5982072347d8cff9742c85d0affd3dd9d86a4fa809f7a91058945a2771b50',
+        'linux': '97de55a5d4353c17eb9b8941c56ed1032fa21f98d991d953c6db47cb54659917'
     }
 
     def __init__(self, only_find_existing=False):
@@ -402,7 +402,7 @@ class Installer:
                 os.remove(download_dest_path)
 
         if need_to_download:
-            logging.info("Downloading %s to %s", download_url, download_dest_path)
+            print("Downloading %s to %s", download_url, download_dest_path)
             downloaded_sha256_sum = download_file(download_url, download_dest_path)
             if downloaded_sha256_sum != expected_sha256_sum:
                 raise IOError(
@@ -714,7 +714,7 @@ class ClusterOptions:
                 if installation_finder.install_or_find_existing():
                     self.installation_dir = installation_finder.installation_dir
                 if not self.installation_dir:
-                    raise RuntimeError(
+                    raise ExitWithError(
                         "Failed to determine YugaByte DB installation directory. Directories "
                         "considered:\n%s\nPlease specify --install-if-needed to download and "
                         "install YugaByte DB automatically." %
@@ -758,29 +758,19 @@ class ClusterOptions:
 
     def get_host_port(self, daemon_id, port_type):
         base_local_url = daemon_id.get_ip_address()
-        if port_type.endswith('_protocol'):
-            port_str = str(self.get_client_protocol_port(port_type.split('_')[0]))
+        if port_type in PROTOCOL_TYPES:
+            port_str = str(self.get_client_protocol_port(port_type))
         else:
             port_str = str(self.base_ports[daemon_id.daemon_type][port_type])
         return "{}:{}".format(base_local_url, port_str)
 
     def get_client_protocol_port(self, protocol_type):
-        attr_value = self.cluster_config.get(protocol_type + '_port')
-        if attr_value is not None:
-            return attr_value
         return self.base_ports[protocol_type]['rpc']
 
     def set_cluster_config(self, cluster_config):
         self.cluster_config = cluster_config
-
-    def get_ysql_port(self):
-        return self.get_client_protocol_port('ysql')
-
-    def get_ycql_port(self):
-        return self.get_client_protocol_port('ycql')
-
-    def get_yedis_port(self):
-        return self.get_client_protocol_port('yedis')
+        if 'base_ports' in cluster_config:
+            self.base_ports = cluster_config['base_ports']
 
     def get_client_tool_path(self, client_tool_name):
         tool_abs_path = os.path.abspath(
@@ -1186,8 +1176,8 @@ class ClusterControl:
             "--tserver_master_addrs={}".format(self.options.master_addresses),
             "--memory_limit_hard_bytes={}".format(1024 * 1024 * 1024),
             "--yb_num_shards_per_tserver={}".format(self.options.num_shards_per_tserver),
-            "--redis_proxy_bind_address=" + get_host_port('yedis_protocol'),
-            "--cql_proxy_bind_address=" + get_host_port('ycql_protocol'),
+            "--redis_proxy_bind_address=" + get_host_port('yedis'),
+            "--cql_proxy_bind_address=" + get_host_port('ycql'),
             "--local_ip_for_outbound_sockets=" + daemon_id.get_ip_address(),
             # TODO ENG-2876: Enable this in master as well.
             "--use_cassandra_authentication={}".format(
@@ -1196,7 +1186,7 @@ class ClusterControl:
         if self.is_ysql_enabled():
             command_list += [
                 "--start_pgsql_proxy",
-                "--pgsql_proxy_bind_address=" + get_host_port('ysql_protocol')
+                "--pgsql_proxy_bind_address=" + get_host_port('ysql')
             ]
         return self.customize_flags(command_list, self.options.tserver_flags)
 
@@ -1455,7 +1445,7 @@ class ClusterControl:
         # -----------------------------------------------------------------------------------------
 
         if self.is_ysql_enabled():
-            ysql_port = self.options.get_ysql_port()
+            ysql_port = self.options.get_client_protocol_port('ysql')
             ysqlsh_cmd_line = format_cmd_line_with_host_port(
                 self.options.get_client_tool_path('ysqlsh'), tserver_ip_address, ysql_port,
                 YSQL_DEFAULT_PORT)
@@ -1470,7 +1460,7 @@ class ClusterControl:
         # cqlsh command line
         # -----------------------------------------------------------------------------------------
 
-        ycql_port = self.options.get_ycql_port()
+        ycql_port = self.options.get_client_protocol_port('ycql')
         cqlsh_cmd_line = self.options.get_client_tool_path('cqlsh')
         if tserver_ip_address != LOCALHOST_IP or ycql_port != YCQL_DEFAULT_PORT:
             cqlsh_cmd_line += ' %s' % tserver_ip_address
@@ -1485,7 +1475,7 @@ class ClusterControl:
         # -----------------------------------------------------------------------------------------
 
         # TODO: should probably not even display this if we can know it's not there...
-        yedis_port = self.options.get_yedis_port()
+        yedis_port = self.options.get_client_protocol_port('yedis')
         redis_cli_cmd_line = format_cmd_line_with_host_port(
             self.options.get_client_tool_path('redis-cli'), tserver_ip_address, yedis_port,
             YEDIS_DEFAULT_PORT)
@@ -1558,9 +1548,7 @@ class ClusterControl:
             attr_value = getattr(self.options, attr_name)
             if attr_value is not None:
                 self.cluster_config[attr_name] = attr_value
-        for protocol_type in PROTOCOL_TYPES:
-            port = self.options.base_ports[protocol_type]['rpc']
-            self.cluster_config[protocol_type + '_port'] = port
+        self.cluster_config['ports'] = self.options.base_ports
 
         server_counts_map = {
             DAEMON_TYPE_MASTER: server_counts,

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -90,18 +90,19 @@ DAEMON_TYPES = [
     DAEMON_TYPE_TSERVER
 ]
 
-YCQL_DEFAULT_PORT = 9042
 YSQL_DEFAULT_PORT = 5433
+YCQL_DEFAULT_PORT = 9042
+YEDIS_DEFAULT_PORT = 6379
 
 TSERVER_DEFAULT_PORTS = {
     "http": 9000,
     "rpc": 9100,
-    "yedis_http": 11000,
-    "yedis_protocol": 6379,
+    "ysql_http": 13000,
+    "ysql_protocol": YSQL_DEFAULT_PORT,
     "ycql_http": 12000,
     "ycql_protocol": YCQL_DEFAULT_PORT,
-    # TODO: add ysql_http when we have it.
-    "ysql_protocol": YSQL_DEFAULT_PORT
+    "yedis_http": 11000,
+    "yedis_protocol": YEDIS_DEFAULT_PORT,
 }
 
 LOCALHOST_IP = '127.0.0.1'
@@ -188,6 +189,18 @@ def wait_for_proc_report_progress(proc):
 def is_env_var_true(env_var_name):
     env_var_value = os.getenv(env_var_name)
     return env_var_value and env_var_value.strip().lower() not in ['n', 'no', '0', 'f', 'false']
+
+
+def format_cmd_line_with_host_port(executable, host, port, default_port):
+    """
+    Adds -h host -p port options if necessary. This works for ysqlsh (psql) and redis-cli.
+    """
+    cmd_line = str(executable)
+    if host != LOCALHOST_IP:
+        cmd_line += ' -h %s' % host
+    if port != default_port:
+        cmd_line += ' -p %d' % port
+    return cmd_line
 
 
 DISABLE_CALLHOME_ENV_VAR_SET = is_env_var_true('YB_DISABLE_CALLHOME')
@@ -504,7 +517,6 @@ class ClusterOptions:
     def __init__(self):
         self.max_daemon_index = 20
         self.num_shards_per_tserver = None
-        self.replication_factor = DEFAULT_REPLICATION_FACTOR
         self.timeout = None
 
         self.cluster_base_dir = None
@@ -514,7 +526,6 @@ class ClusterOptions:
 
         self.installation_dir = None
 
-        self.num_drives = None
         self.placement_cloud = "cloud"
         self.placement_region = "region"
         self.placement_zone = "zone"
@@ -537,10 +548,18 @@ class ClusterOptions:
         self.node_type = DAEMON_TYPE_TSERVER
         self.is_shell_master = False
         self.is_startup_command = False
-        self.enable_ysql = None
         self.install_if_needed = False
         self.yb_ctl_verbose = False
+
         self.cluster_config = None
+
+        # These fields are saved into the cluster configuration.
+        self.enable_ysql = None
+        self.num_drives = None
+        self.replication_factor = DEFAULT_REPLICATION_FACTOR
+        self.ysql_port = None
+        self.ycql_port = None
+        self.yedis_port = None
 
     def parse_flag_args(self, flag_args):
         flags = [] if flag_args is None else flag_args.split(",")
@@ -661,13 +680,11 @@ class ClusterOptions:
         self.yedis_port = None
         for api_name_str in ['ysql', 'ycql', 'yedis']:
             port_option_str = api_name_str + '_port'
-            logging.info("PORT OPTION STR: %s", port_option_str)
             port = getattr(args, port_option_str, None)
             if port is not None:
                 if port < 1 or port > 65535:
                     raise ExitWithError("Invalid port specified for option --%s: %d" % (
                         port_option_str, port))
-                logging.info("FOUND PORT: %s %s", port_option_str, port)
                 setattr(self, api_name_str + '_port', port)
 
         # -----------------------------------------------------------------------------------------
@@ -728,10 +745,13 @@ class ClusterOptions:
         raise RuntimeError("No binary found for {}. Considered binary directories: {}".format(
             binary_name, binary_dirs))
 
-    def get_address(self, daemon_id, port_type, include_base_url=False):
-        port_str = str(self.base_ports[daemon_id.daemon_type][port_type])
+    def get_host_port(self, daemon_id, port_type):
         base_local_url = daemon_id.get_ip_address()
-        return port_str if not include_base_url else "{}:{}".format(base_local_url, port_str)
+        if port_type.endswith('_protocol'):
+            port_str = str(self.get_client_protocol_port(port_type.split('_')[0]))
+        else:
+            port_str = str(self.base_ports[daemon_id.daemon_type][port_type])
+        return "{}:{}".format(base_local_url, port_str)
 
     def get_client_protocol_port(self, api_name_str):
         attr_name = api_name_str + '_port'
@@ -1156,20 +1176,15 @@ class ClusterControl:
         return self.customize_flags(command_list, self.options.master_flags)
 
     def get_tserver_only_flags(self, daemon_id):
-        daemon_ip_address_str = str(daemon_id.get_ip_address())
-
-        def get_host_port(api_name_str):
-            return '%s:%s' % (
-                daemon_ip_address_str,
-                self.options.get_client_protocol_port(api_name_str))
-
+        def get_host_port(port_type):
+            return self.options.get_host_port(daemon_id, port_type)
         command_list = [
             "--tserver_master_addrs={}".format(self.options.master_addresses),
             "--memory_limit_hard_bytes={}".format(1024 * 1024 * 1024),
             "--yb_num_shards_per_tserver={}".format(self.options.num_shards_per_tserver),
-            "--redis_proxy_bind_address=" + get_host_port('yedis'),
-            "--cql_proxy_bind_address=" + get_host_port('ycql'),
-            "--local_ip_for_outbound_sockets=" + daemon_ip_address_str,
+            "--redis_proxy_bind_address=" + get_host_port('yedis_protocol'),
+            "--cql_proxy_bind_address=" + get_host_port('ycql_protocol'),
+            "--local_ip_for_outbound_sockets=" + daemon_id.get_ip_address(),
             # TODO ENG-2876: Enable this in master as well.
             "--use_cassandra_authentication={}".format(
                 str(self.options.use_cassandra_authentication).lower())
@@ -1177,7 +1192,7 @@ class ClusterControl:
         if self.is_ysql_enabled():
             command_list += [
                 "--start_pgsql_proxy",
-                "--pgsql_proxy_bind_address=" + get_host_port('ysql')
+                "--pgsql_proxy_bind_address=" + get_host_port('ysql_protocol')
             ]
         return self.customize_flags(command_list, self.options.tserver_flags)
 
@@ -1194,7 +1209,7 @@ class ClusterControl:
         """
         num_servers = self.get_number_of_servers(DAEMON_TYPE_MASTER)
         self.options.master_addresses = ",".join(
-            [self.options.get_address(DaemonId(DAEMON_TYPE_MASTER, i), "rpc", include_base_url=True)
+            [self.options.get_host_port(DaemonId(DAEMON_TYPE_MASTER, i), "rpc")
              for i in range(1, num_servers + 1)
              if not running_only or self.get_pid(DaemonId(DAEMON_TYPE_MASTER, i)) is not None])
 
@@ -1368,8 +1383,8 @@ class ClusterControl:
                 # aware of it because we do not have a yb-admin API to return only live tablet
                 # servers.
                 for i in range(num_alive_ts):
-                    ts_hp = self.options.get_address(
-                        DaemonId(DAEMON_TYPE_TSERVER, i + 1), "rpc", include_base_url=True)
+                    ts_hp = self.options.get_host_port(
+                        DaemonId(DAEMON_TYPE_TSERVER, i + 1), "rpc")
                     if ts_hp not in output:
                         logging.error("Could not find TS info ('{}') in yb-admin output: {}".format(
                             ts_hp, output))
@@ -1412,8 +1427,7 @@ class ClusterControl:
         info_kv_list.extend([
             # TODO: this might cause issues if the first master is down...
             ("Web UI", "http://{}/".format(
-                self.options.get_address(
-                    DaemonId(DAEMON_TYPE_MASTER, 1), "http", include_base_url=True))),
+                self.options.get_host_port(DaemonId(DAEMON_TYPE_MASTER, 1), "http"))),
             ("Cluster Data", self.options.cluster_base_dir)
         ])
         self.print_status_box(title, info_kv_list)
@@ -1438,11 +1452,10 @@ class ClusterControl:
 
         if self.is_ysql_enabled():
             ysql_port = self.options.get_ysql_port()
-            ysqlsh_cmd_line = self.options.get_client_tool_path('ysqlsh')
-            if tserver_ip_address != LOCALHOST_IP:
-                ysqlsh_cmd_line += ' -h %s' % tserver_ip_address
-            if ysql_port != YSQL_DEFAULT_PORT:
-                ysqlsh_cmd_line += ' -p %s' % ysql_port
+            ysqlsh_cmd_line = format_cmd_line_with_host_port(
+                self.options.get_client_tool_path('ysqlsh'), tserver_ip_address, ysql_port,
+                YSQL_DEFAULT_PORT)
+
             info_kv_list.extend([
                 ("JDBC", "postgresql://postgres@{}:{}".format(
                     tserver_ip_address, ysql_port)),
@@ -1469,9 +1482,9 @@ class ClusterControl:
 
         # TODO: should probably not even display this if we can know it's not there...
         yedis_port = self.options.get_yedis_port()
-        redis_cli_cmd_line = "{} -h {} -p {}".format(
-                self.options.get_client_tool_path('redis-cli'),
-                tserver_daemon_id.get_ip_address(), yedis_port)
+        redis_cli_cmd_line = format_cmd_line_with_host_port(
+            self.options.get_client_tool_path('redis-cli'), tserver_ip_address, yedis_port,
+            YEDIS_DEFAULT_PORT)
         info_kv_list.append(("YEDIS Shell", redis_cli_cmd_line))
         return info_kv_list
 
@@ -1618,12 +1631,8 @@ class ClusterControl:
     def wipe_restart_cmd_impl(self):
         num_servers_map = self.get_number_of_servers_map()
         self.set_master_addresses()
-        self.destroy()
-        print("Starting cluster.")
-        self.start_helper(num_servers_map)
-        self.wait_for_cluster_or_raise()
-        self.modify_placement_info()
-        self.cluster_status()
+        self.destroy_cmd_impl()
+        self.create_cmd_impl()
 
     def add_node_cmd_impl(self):
         print("Adding node.")

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -769,8 +769,9 @@ class ClusterOptions:
 
     def set_cluster_config(self, cluster_config):
         self.cluster_config = cluster_config
-        if 'base_ports' in cluster_config:
-            self.base_ports = cluster_config['base_ports']
+        base_ports_from_config = cluster_config.get('ports')
+        if base_ports_from_config is not None:
+            self.base_ports = base_ports_from_config
 
     def get_client_tool_path(self, client_tool_name):
         tool_abs_path = os.path.abspath(

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -90,6 +90,22 @@ DAEMON_TYPES = [
     DAEMON_TYPE_TSERVER
 ]
 
+YCQL_DEFAULT_PORT = 9042
+YSQL_DEFAULT_PORT = 5433
+
+TSERVER_DEFAULT_PORTS = {
+    "http": 9000,
+    "rpc": 9100,
+    "yedis_http": 11000,
+    "yedis_protocol": 6379,
+    "ycql_http": 12000,
+    "ycql_protocol": YCQL_DEFAULT_PORT,
+    # TODO: add ysql_http when we have it.
+    "ysql_protocol": YSQL_DEFAULT_PORT
+}
+
+LOCALHOST_IP = '127.0.0.1'
+
 SLEEP_TIME_IN_SEC = 1
 MAX_WAIT_SECONDS = 45
 DEFAULT_REPLICATION_FACTOR = 1
@@ -509,16 +525,7 @@ class ClusterOptions:
                     "http": 7000,
                     "rpc": 7100
                 },
-                DAEMON_TYPE_TSERVER: {
-                    "http": 9000,
-                    "rpc": 9100,
-                    "yedis_http": 11000,
-                    "yedis_rpc": 6379,
-                    "ycql_http": 12000,
-                    "ycql_rpc": 9042,
-                    # TODO: add ysql_http when we have it.
-                    "ysql_rpc": 5433
-                }
+                DAEMON_TYPE_TSERVER: TSERVER_DEFAULT_PORTS
         }
 
         self.master_flags = []
@@ -533,6 +540,7 @@ class ClusterOptions:
         self.enable_ysql = None
         self.install_if_needed = False
         self.yb_ctl_verbose = False
+        self.cluster_config = None
 
     def parse_flag_args(self, flag_args):
         flags = [] if flag_args is None else flag_args.split(",")
@@ -617,6 +625,10 @@ class ClusterOptions:
         if hasattr(args, "master") and args.master:
             self.node_type = DAEMON_TYPE_MASTER
 
+        # -----------------------------------------------------------------------------------------
+        # Controlling whether to enable or disable YSQL
+        # -----------------------------------------------------------------------------------------
+
         ysql_explicitly_enabled = False
         ysql_explicitly_disabled = False
 
@@ -639,6 +651,28 @@ class ClusterOptions:
 
         if self.enable_ysql is None:
             self.enable_ysql = True
+
+        # -----------------------------------------------------------------------------------------
+        # Client protocol ports
+        # -----------------------------------------------------------------------------------------
+
+        self.ysql_port = None
+        self.ycql_port = None
+        self.yedis_port = None
+        for api_name_str in ['ysql', 'ycql', 'yedis']:
+            port_option_str = api_name_str + '_port'
+            logging.info("PORT OPTION STR: %s", port_option_str)
+            port = getattr(args, port_option_str, None)
+            if port is not None:
+                if port < 1 or port > 65535:
+                    raise ExitWithError("Invalid port specified for option --%s: %d" % (
+                        port_option_str, port))
+                logging.info("FOUND PORT: %s %s", port_option_str, port)
+                setattr(self, api_name_str + '_port', port)
+
+        # -----------------------------------------------------------------------------------------
+        # Automatic YugaByte DB installation
+        # -----------------------------------------------------------------------------------------
 
         if args.install_if_needed and not self.installation_dir:
             installer = Installer()
@@ -699,6 +733,45 @@ class ClusterOptions:
         base_local_url = daemon_id.get_ip_address()
         return port_str if not include_base_url else "{}:{}".format(base_local_url, port_str)
 
+    def get_client_protocol_port(self, api_name_str):
+        attr_name = api_name_str + '_port'
+        attr_value = getattr(self, attr_name)
+        if attr_value is not None:
+            return attr_value
+        attr_value = self.cluster_config.get(attr_name)
+        if attr_value is not None:
+            return attr_value
+        return TSERVER_DEFAULT_PORTS[api_name_str + '_protocol']
+
+    def set_cluster_config(self, cluster_config):
+        self.cluster_config = cluster_config
+
+    def get_ysql_port(self):
+        return self.get_client_protocol_port('ysql')
+
+    def get_ycql_port(self):
+        return self.get_client_protocol_port('ycql')
+
+    def get_yedis_port(self):
+        return self.get_client_protocol_port('yedis')
+
+    def get_client_tool_path(self, client_tool_name):
+        tool_abs_path = os.path.abspath(
+                os.path.join(self.installation_dir, 'bin', client_tool_name))
+        cur_dir_abs_path = os.path.abspath(os.getcwd())
+        home_dir_abs_path = os.path.abspath(os.path.expanduser('~'))
+        path_rel_to_cur = os.path.relpath(tool_abs_path, cur_dir_abs_path)
+        path_rel_to_home = '~/' + os.path.relpath(tool_abs_path, home_dir_abs_path)
+        candidates = [tool_abs_path, path_rel_to_cur, path_rel_to_home]
+        min_len = None
+        for i in range(len(candidates)):
+            cur_len = len(candidates[i])
+            if min_len is None or cur_len < min_len:
+                min_len = cur_len
+                shortest_path = candidates[i]
+        return shortest_path
+
+
 # End of ClusterOptions
 # -------------------------------------------------------------------------------------------------
 
@@ -746,7 +819,7 @@ class ClusterControl:
             # No configuration file -- let's create an empty one.
             self.cluster_config = {}
 
-        loaded_cluster_config = json.loads(json.dumps(self.cluster_config))
+        loaded_cluster_config = json.loads(json.dumps(self.cluster_config, sort_keys=True))
         if 'enable_postgres' in self.cluster_config:
             # Migrate the deprecated "enable_postgres" cluster config option to the new format.
             self.cluster_config['enable_ysql'] = (
@@ -755,6 +828,7 @@ class ClusterControl:
             del self.cluster_config['enable_postgres']
         if self.cluster_config != loaded_cluster_config:
             self.save_cluster_config()
+        self.options.set_cluster_config(self.cluster_config)
 
     def save_cluster_config(self):
         cluster_config_path = self.get_cluster_config_file_path()
@@ -889,6 +963,24 @@ class ClusterControl:
                                          action='store_true',
                                          help="Disable YugaByte SQL API.",
                                          default=None)
+
+            subparsers[cmd].add_argument(
+                    "--ysql_port",
+                    help="YSQL (PostgreSQL-compatible) API port. Default: %d." %
+                         TSERVER_DEFAULT_PORTS['ysql_protocol'],
+                    type=int)
+
+            subparsers[cmd].add_argument(
+                    "--ycql_port",
+                    help="YCQL (Cassandra-compatible) API port. Default: %d." %
+                         TSERVER_DEFAULT_PORTS['ycql_protocol'],
+                    type=int)
+
+            subparsers[cmd].add_argument(
+                    "--yedis_port",
+                    help="YEDIS (Redis-compatible) API port. Default. %d." %
+                         TSERVER_DEFAULT_PORTS['yedis_protocol'],
+                    type=int)
 
             subparsers[cmd].add_argument(
                 "--num_drives", default=1, type=int,
@@ -1065,12 +1157,18 @@ class ClusterControl:
 
     def get_tserver_only_flags(self, daemon_id):
         daemon_ip_address_str = str(daemon_id.get_ip_address())
+
+        def get_host_port(api_name_str):
+            return '%s:%s' % (
+                daemon_ip_address_str,
+                self.options.get_client_protocol_port(api_name_str))
+
         command_list = [
             "--tserver_master_addrs={}".format(self.options.master_addresses),
             "--memory_limit_hard_bytes={}".format(1024 * 1024 * 1024),
             "--yb_num_shards_per_tserver={}".format(self.options.num_shards_per_tserver),
-            "--redis_proxy_bind_address=" + daemon_ip_address_str,
-            "--cql_proxy_bind_address=" + daemon_ip_address_str,
+            "--redis_proxy_bind_address=" + get_host_port('yedis'),
+            "--cql_proxy_bind_address=" + get_host_port('ycql'),
             "--local_ip_for_outbound_sockets=" + daemon_ip_address_str,
             # TODO ENG-2876: Enable this in master as well.
             "--use_cassandra_authentication={}".format(
@@ -1079,7 +1177,7 @@ class ClusterControl:
         if self.is_ysql_enabled():
             command_list += [
                 "--start_pgsql_proxy",
-                "--pgsql_proxy_bind_address=" + daemon_ip_address_str
+                "--pgsql_proxy_bind_address=" + get_host_port('ysql')
             ]
         return self.customize_flags(command_list, self.options.tserver_flags)
 
@@ -1331,20 +1429,50 @@ class ClusterControl:
         info_kv_list = []
         if not tserver_daemon_id:
             return info_kv_list
+
+        tserver_ip_address = tserver_daemon_id.get_ip_address()
+
+        # -----------------------------------------------------------------------------------------
+        # ysqlsh command line
+        # -----------------------------------------------------------------------------------------
+
         if self.is_ysql_enabled():
-            ysql_port = self.options.base_ports[tserver_daemon_id.daemon_type]["ysql_rpc"]
+            ysql_port = self.options.get_ysql_port()
+            ysqlsh_cmd_line = self.options.get_client_tool_path('ysqlsh')
+            if tserver_ip_address != LOCALHOST_IP:
+                ysqlsh_cmd_line += ' -h %s' % tserver_ip_address
+            if ysql_port != YSQL_DEFAULT_PORT:
+                ysqlsh_cmd_line += ' -p %s' % ysql_port
             info_kv_list.extend([
                 ("JDBC", "postgresql://postgres@{}:{}".format(
-                    tserver_daemon_id.get_ip_address(), ysql_port)),
-                ("YSQL Shell", "./bin/ysqlsh")
+                    tserver_ip_address, ysql_port)),
+                ("YSQL Shell", ysqlsh_cmd_line)
             ])
+
+        # -----------------------------------------------------------------------------------------
+        # cqlsh command line
+        # -----------------------------------------------------------------------------------------
+
+        ycql_port = self.options.get_ycql_port()
+        cqlsh_cmd_line = self.options.get_client_tool_path('cqlsh')
+        if tserver_ip_address != LOCALHOST_IP or ycql_port != YCQL_DEFAULT_PORT:
+            cqlsh_cmd_line += ' %s' % tserver_ip_address
+            if ycql_port != YCQL_DEFAULT_PORT:
+                cqlsh_cmd_line += ' %s' % ycql_port
+
         info_kv_list.append(
-            ("YCQL Shell", "./bin/cqlsh"))
+            ("YCQL Shell", cqlsh_cmd_line))
+
+        # -----------------------------------------------------------------------------------------
+        # redis-cli command line
+        # -----------------------------------------------------------------------------------------
+
         # TODO: should probably not even display this if we can know it's not there...
-        yedis_port = self.options.base_ports[tserver_daemon_id.daemon_type]["yedis_rpc"]
-        info_kv_list.append(
-            ("YEDIS Shell", "./bin/redis-cli -h {} -p {}".format(
-                tserver_daemon_id.get_ip_address(), yedis_port)))
+        yedis_port = self.options.get_yedis_port()
+        redis_cli_cmd_line = "{} -h {} -p {}".format(
+                self.options.get_client_tool_path('redis-cli'),
+                tserver_daemon_id.get_ip_address(), yedis_port)
+        info_kv_list.append(("YEDIS Shell", redis_cli_cmd_line))
         return info_kv_list
 
     def show_node_status(self, daemon_index, server_counts=None):
@@ -1402,11 +1530,20 @@ class ClusterControl:
         self.creating_cluster = True
         server_counts = self.options.replication_factor
         self.set_master_addresses()
-        self.cluster_config = {
-            "enable_ysql": self.options.enable_ysql,
-            "num_drives": self.options.num_drives,
-            "replication_factor": self.options.replication_factor
-        }
+        self.cluster_config = {}
+        self.options.set_cluster_config(self.cluster_config)
+
+        for attr_name in (
+            "enable_ysql",
+            "num_drives",
+            "replication_factor",
+            "ysql_port",
+            "ycql_port",
+            "yedis_port",
+        ):
+            attr_value = getattr(self.options, attr_name)
+            if attr_value is not None:
+                self.cluster_config[attr_name] = attr_value
 
         server_counts_map = {
             DAEMON_TYPE_MASTER: server_counts,

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -84,26 +84,24 @@ import urllib
 
 DAEMON_TYPE_MASTER = 'master'
 DAEMON_TYPE_TSERVER = 'tserver'
+PROTOCOL_TYPE_YSQL = 'ysql'
+PROTOCOL_TYPE_YCQL = 'ycql'
+PROTOCOL_TYPE_YEDIS = 'yedis'
 
 DAEMON_TYPES = [
     DAEMON_TYPE_MASTER,
     DAEMON_TYPE_TSERVER
 ]
 
+PROTOCOL_TYPES = {
+    PROTOCOL_TYPE_YSQL,
+    PROTOCOL_TYPE_YCQL,
+    PROTOCOL_TYPE_YEDIS
+}
+
 YSQL_DEFAULT_PORT = 5433
 YCQL_DEFAULT_PORT = 9042
 YEDIS_DEFAULT_PORT = 6379
-
-TSERVER_DEFAULT_PORTS = {
-    "http": 9000,
-    "rpc": 9100,
-    "ysql_http": 13000,
-    "ysql_protocol": YSQL_DEFAULT_PORT,
-    "ycql_http": 12000,
-    "ycql_protocol": YCQL_DEFAULT_PORT,
-    "yedis_http": 11000,
-    "yedis_protocol": YEDIS_DEFAULT_PORT,
-}
 
 LOCALHOST_IP = '127.0.0.1'
 
@@ -513,6 +511,31 @@ class DaemonId:
         return self.daemon_type in [DAEMON_TYPE_MASTER, DAEMON_TYPE_TSERVER]
 
 
+def get_default_base_ports_dict():
+    return {
+        DAEMON_TYPE_MASTER: {
+            "http": 7000,
+            "rpc": 7100
+        },
+        DAEMON_TYPE_TSERVER: {
+            "http": 9000,
+            "rpc": 9100,
+        },
+        PROTOCOL_TYPE_YSQL: {
+            "http": 13000,
+            "rpc": YSQL_DEFAULT_PORT
+        },
+        PROTOCOL_TYPE_YCQL: {
+            "http": 12000,
+            "rpc": YCQL_DEFAULT_PORT,
+        },
+        PROTOCOL_TYPE_YEDIS: {
+            "http": 11000,
+            "rpc": YEDIS_DEFAULT_PORT
+        }
+    }
+
+
 class ClusterOptions:
     def __init__(self):
         self.max_daemon_index = 20
@@ -531,13 +554,7 @@ class ClusterOptions:
         self.placement_zone = "zone"
 
         self.master_addresses = ""
-        self.base_ports = {
-                DAEMON_TYPE_MASTER: {
-                    "http": 7000,
-                    "rpc": 7100
-                },
-                DAEMON_TYPE_TSERVER: TSERVER_DEFAULT_PORTS
-        }
+        self.base_ports = get_default_base_ports_dict()
 
         self.master_flags = []
         self.tserver_flags = []
@@ -557,9 +574,6 @@ class ClusterOptions:
         self.enable_ysql = None
         self.num_drives = None
         self.replication_factor = DEFAULT_REPLICATION_FACTOR
-        self.ysql_port = None
-        self.ycql_port = None
-        self.yedis_port = None
 
     def parse_flag_args(self, flag_args):
         flags = [] if flag_args is None else flag_args.split(",")
@@ -675,17 +689,14 @@ class ClusterOptions:
         # Client protocol ports
         # -----------------------------------------------------------------------------------------
 
-        self.ysql_port = None
-        self.ycql_port = None
-        self.yedis_port = None
-        for api_name_str in ['ysql', 'ycql', 'yedis']:
-            port_option_str = api_name_str + '_port'
+        for protocol_type in PROTOCOL_TYPES:
+            port_option_str = protocol_type + '_port'
             port = getattr(args, port_option_str, None)
             if port is not None:
                 if port < 1 or port > 65535:
                     raise ExitWithError("Invalid port specified for option --%s: %d" % (
                         port_option_str, port))
-                setattr(self, api_name_str + '_port', port)
+                self.base_ports[protocol_type]['rpc'] = port
 
         # -----------------------------------------------------------------------------------------
         # Automatic YugaByte DB installation
@@ -753,15 +764,11 @@ class ClusterOptions:
             port_str = str(self.base_ports[daemon_id.daemon_type][port_type])
         return "{}:{}".format(base_local_url, port_str)
 
-    def get_client_protocol_port(self, api_name_str):
-        attr_name = api_name_str + '_port'
-        attr_value = getattr(self, attr_name)
+    def get_client_protocol_port(self, protocol_type):
+        attr_value = self.cluster_config.get(protocol_type + '_port')
         if attr_value is not None:
             return attr_value
-        attr_value = self.cluster_config.get(attr_name)
-        if attr_value is not None:
-            return attr_value
-        return TSERVER_DEFAULT_PORTS[api_name_str + '_protocol']
+        return self.base_ports[protocol_type]['rpc']
 
     def set_cluster_config(self, cluster_config):
         self.cluster_config = cluster_config
@@ -986,20 +993,17 @@ class ClusterControl:
 
             subparsers[cmd].add_argument(
                     "--ysql_port",
-                    help="YSQL (PostgreSQL-compatible) API port. Default: %d." %
-                         TSERVER_DEFAULT_PORTS['ysql_protocol'],
+                    help="YSQL (PostgreSQL-compatible) API port. Default: %d." % YSQL_DEFAULT_PORT,
                     type=int)
 
             subparsers[cmd].add_argument(
                     "--ycql_port",
-                    help="YCQL (Cassandra-compatible) API port. Default: %d." %
-                         TSERVER_DEFAULT_PORTS['ycql_protocol'],
+                    help="YCQL (Cassandra-compatible) API port. Default: %d." % YCQL_DEFAULT_PORT,
                     type=int)
 
             subparsers[cmd].add_argument(
                     "--yedis_port",
-                    help="YEDIS (Redis-compatible) API port. Default. %d." %
-                         TSERVER_DEFAULT_PORTS['yedis_protocol'],
+                    help="YEDIS (Redis-compatible) API port. Default. %d." % YEDIS_DEFAULT_PORT,
                     type=int)
 
             subparsers[cmd].add_argument(
@@ -1549,14 +1553,14 @@ class ClusterControl:
         for attr_name in (
             "enable_ysql",
             "num_drives",
-            "replication_factor",
-            "ysql_port",
-            "ycql_port",
-            "yedis_port",
+            "replication_factor"
         ):
             attr_value = getattr(self.options, attr_name)
             if attr_value is not None:
                 self.cluster_config[attr_name] = attr_value
+        for protocol_type in PROTOCOL_TYPES:
+            port = self.options.base_ports[protocol_type]['rpc']
+            self.cluster_config[protocol_type + '_port'] = port
 
         server_counts_map = {
             DAEMON_TYPE_MASTER: server_counts,

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -258,17 +258,17 @@ log_heading "Testing YSQL port override"
   verify_ysqlsh 1 54320
 (
   set -x
-  "$python_interpreter" bin/yb-ctl stop
+  "$python_interpreter" bin/yb-ctl stop "${yb_ctl_args[@]}"
 )
 log "Checking that the custom YSQL port persists across restarts"
 (
   set -x
-  "$python_interpreter" bin/yb-ctl start
+  "$python_interpreter" bin/yb-ctl start "${yb_ctl_args[@]}"
 )
 verify_ysqlsh 1 54320
 (
   set -x
-  "$python_interpreter" bin/yb-ctl destroy
+  "$python_interpreter" bin/yb-ctl destroy "${yb_ctl_args[@]}"
 )
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Ports are specified using --ysql_port, --ycql_port, --yedis_port options. These ports are persisted in the cluster_config.json file in the data directory. Also modifying ysqlsh / cqlsh / redis-cli command lines shown by the status command so that they specify the correct node IP and port.

```
----------------------------------------------------------------------------------------------------
| Node Count: 3 | Replication Factor: 1                                                            |
----------------------------------------------------------------------------------------------------
| JDBC                : postgresql://postgres@127.0.0.1:54320                                      |
| YSQL Shell          : ~/yugabyte-db/yugabyte-1.2.10.0/bin/ysqlsh -p 54320                        |
| YCQL Shell          : ~/yugabyte-db/yugabyte-1.2.10.0/bin/cqlsh 127.0.0.1 9043                   |
| YEDIS Shell         : ~/yugabyte-db/yugabyte-1.2.10.0/bin/redis-cli -h 127.0.0.1 -p 6999         |
| Web UI              : http://127.0.0.1:7000/                                                     |
| Cluster Data        : /Users/mbautin/yugabyte-data                                               |
----------------------------------------------------------------------------------------------------
```

Also updating the YugaByte DB version that gets installed with the `--install-if-needed` option to 1.2.11.0.

This commit addresses this issue: https://github.com/YugaByte/yugabyte-db/issues/1641