### PR TITLE
Detect missing processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.sw?
 *.bak
 *.rej
+venv/
+*.log

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1317,6 +1317,15 @@ class ClusterControl:
                  "Use --data_dir to specify a different data directory.").format(
                     self.options.cluster_base_dir))
 
+        # Make sure that there are no `yb-` processes before the `create`.
+        pids = self.for_all_daemons(self.get_pid, server_counts_map)
+        if self.args.verbose:
+            logging.info(
+                "PIDs found when looking for daemons before starting daemons in `create`: "
+                "{}".format(pids))
+        if any(sum(pids.values(), [])):
+            raise ExitWithError("Processes are still up. Make sure to destroy old state.")
+
         os.makedirs(self.options.cluster_base_dir)
         self.for_all_daemons(self.start_daemon, server_counts_map)
 
@@ -1523,7 +1532,10 @@ class ClusterControl:
     def for_all_daemons(self, fn, server_counts_map=None):
         """
         Run the given function for all daemons.
+
+        Returns the return values of each function call.
         """
+        fn_returns = {daemon_type: [] for daemon_type in DAEMON_TYPES}
         for daemon_type in DAEMON_TYPES:
             if server_counts_map:
                 num_servers = server_counts_map[daemon_type]
@@ -1531,7 +1543,8 @@ class ClusterControl:
                 num_servers = self.get_number_of_servers(daemon_type)
 
             for daemon_index in range(1, num_servers + 1):
-                fn(DaemonId(daemon_type, daemon_index))
+                fn_returns[daemon_type].append(fn(DaemonId(daemon_type, daemon_index)))
+        return fn_returns
 
     def create_cmd_impl(self):
         print("Creating cluster.")

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1365,19 +1365,19 @@ class ClusterControl:
         if not retry_call_with_timeout(call_change_config, self.options.timeout):
             raise ExitWithError("Could not change master config...")
 
-    def keep_and_dump_log(self, log_path):
+    def dump_file_to_stderr(self, file_path):
         """
-        Keeps log file intact and dumps log file contents to STDERR.
+        Keep file intact and dump file contents to STDERR.
 
-        :param log_path: path to the log file, assumed to exist
-        :type log_path: str
+        :param file_path: path to the file, assumed to exist
+        :type file_path: str
         """
-        print("Viewing log at {}:".format(log_path), file=sys.stderr)
-        with open(log_path, "rb") as log:
+        print("Viewing file {}:".format(file_path), file=sys.stderr)
+        with open(file_path, "rb") as f:
             if sys.version_info[0] >= 3:
-                shutil.copyfileobj(log, sys.stderr.buffer)
+                shutil.copyfileobj(f, sys.stderr.buffer)
             else:
-                shutil.copyfileobj(log, sys.stderr)
+                shutil.copyfileobj(f, sys.stderr)
 
     def dump_missing_process_error_logs(self):
         pids = self.for_all_daemons(self.get_pid)
@@ -1388,9 +1388,9 @@ class ClusterControl:
                     daemon_id = DaemonId(daemon_type, index)
                     log_path = self.get_log_path(daemon_id)
                     if os.path.exists(log_path):
-                        self.keep_and_dump_log(log_path)
+                        self.dump_file_to_stderr(log_path)
                     else:
-                        print("Process {0} is down, and there is no corresponding error log at {1}".
+                        print("Process {0} is down, and there is no corresponding error log: {1}".
                               format(daemon_id, log_path), file=sys.stderr)
 
     def wait_for_cluster(self):
@@ -1853,7 +1853,7 @@ class ClusterControl:
         if os.path.isfile(self.log_file):
             # If we called the atexit handler and we have a file, it means we must have had errors.
             if keep_log_file_and_dump_to_stderr:
-                self.keep_and_dump_log(self.log_file)
+                self.dump_file_to_stderr(self.log_file)
                 print("^^^ Encountered errors ^^^")
             # Whichever cleanup comes first should remove the file.
             # TODO: Maybe keep the log file around and allow the user to upload a gist with the log.

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -107,6 +107,7 @@ LOCALHOST_IP = '127.0.0.1'
 
 SLEEP_TIME_IN_SEC = 1
 MAX_WAIT_SECONDS = 45
+MAX_PROCESS_WAIT_SECONDS = 10
 DEFAULT_REPLICATION_FACTOR = 1
 
 # A regex to get data directories out a command line of a running process.
@@ -1379,7 +1380,7 @@ class ClusterControl:
             return all(sum(pids.values(), []))
 
         logging.info("Waiting for master and tserver processes to be up.")
-        if not retry_call_with_timeout(call_check_for_processes, self.options.timeout):
+        if not retry_call_with_timeout(call_check_for_processes, MAX_PROCESS_WAIT_SECONDS):
             self.dump_missing_process_error_logs()
             logging.error("Failed waiting for master and tserver processes to come up.")
             return False

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1246,8 +1246,14 @@ class ClusterControl:
             logging.info("{} already stopped".format(name))
             return
         logging.info("Stopping {} PID={}".format(name, pid))
-        # Kill the process.
-        os.kill(pid, signal.SIGTERM)
+        # Kill the process, if it exists.
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError as e:
+            if e.errno == 3:
+                logging.info("{} does not exist; nothing to stop".format(name))
+            else:
+                raise e
 
         # Wait for process to stop.
         last_msg_time = time.time()

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1348,6 +1348,24 @@ class ClusterControl:
         if not retry_call_with_timeout(call_change_config, self.options.timeout):
             raise ExitWithError("Could not change master config...")
 
+    def dump_missing_process_error_logs(self):
+        pids = self.for_all_daemons(self.get_pid)
+        for daemon_type, pid_list in pids.items():
+            for index, pid in enumerate(pid_list, 1):
+                if pid is None:
+                    daemon_id = DaemonId(daemon_type, index)
+                    node_base_dirs = self.get_base_node_dirs(daemon_id.index)
+                    first_base_dir = node_base_dirs[0]
+                    log_name = daemon_id.daemon_type + ".err"
+                    log_path = os.path.join(first_base_dir, log_name)
+                    if os.path.exists(log_path):
+                        with open(log_path) as log:
+                            print("Viewing log at {}:".format(log_path), file=sys.stderr)
+                            if sys.version_info[0] >= 3:
+                                shutil.copyfileobj(log, sys.stderr.buffer)
+                            else:
+                                shutil.copyfileobj(log, sys.stderr)
+
     def wait_for_cluster(self):
         """
         This will wait for the masters to elect a leader and then keep querying for how many TS
@@ -1364,6 +1382,7 @@ class ClusterControl:
 
         logging.info("Waiting for master and tserver processes to be up.")
         if not retry_call_with_timeout(call_check_for_processes, self.options.timeout):
+            self.dump_missing_process_error_logs()
             logging.error("Failed waiting for master and tserver processes to come up.")
             return False
 
@@ -1383,6 +1402,7 @@ class ClusterControl:
 
         def call_check_for_ts(should_get_error):
             if not call_check_for_processes(should_get_error):
+                self.dump_missing_process_error_logs()
                 raise ExitWithError("At least one master or tserver process is down.")
 
             max_num_tservers = self.get_number_of_servers(DAEMON_TYPE_TSERVER)

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -106,8 +106,8 @@ YEDIS_DEFAULT_PORT = 6379
 LOCALHOST_IP = '127.0.0.1'
 
 SLEEP_TIME_IN_SEC = 1
-MAX_WAIT_SECONDS = 45
-MAX_PROCESS_WAIT_SECONDS = 10
+MAX_YB_ADMIN_WAIT_SECONDS = 45
+MAX_CLUSTER_UP_WAIT_SECONDS = 10
 DEFAULT_REPLICATION_FACTOR = 1
 
 # A regex to get data directories out a command line of a running process.
@@ -135,7 +135,7 @@ def call_get_output_maybe_error(cmd_list, should_get_error=False):
         return output
 
 
-def retry_call_with_timeout(fn, timeout_sec=MAX_WAIT_SECONDS):
+def retry_call_with_timeout(fn, timeout_sec=MAX_YB_ADMIN_WAIT_SECONDS):
     """
     This will retry a given function that is supposed to be doing subprocess callouts. Based on
     the passed in function behavior, this function will behave accordingly:
@@ -541,7 +541,8 @@ class ClusterOptions:
     def __init__(self):
         self.max_daemon_index = 20
         self.num_shards_per_tserver = None
-        self.timeout = None
+        self.timeout_yb_admin = None
+        self.timeout_cluster_up = None
 
         self.cluster_base_dir = None
 
@@ -623,7 +624,8 @@ class ClusterOptions:
         self.custom_binary_dir = args.binary_dir
         self.cluster_base_dir = args.data_dir
         self.num_shards_per_tserver = args.num_shards_per_tserver
-        self.timeout = args.timeout
+        self.timeout_yb_admin = args.timeout_yb_admin
+        self.timeout_cluster_up = args.timeout_cluster_up
 
         if hasattr(args, "v"):
             self.verbose_level = args.v
@@ -925,8 +927,11 @@ class ClusterControl:
             "--num_shards_per_tserver", default=2, type=int,
             help="Number of shards (tablets) to start per tablet server for each table.")
         self.parser.add_argument(
-            "--timeout", default=MAX_WAIT_SECONDS, type=float,
-            help="Timeout in seconds for operations that wait on the cluster")
+            "--timeout-yb-admin", default=MAX_YB_ADMIN_WAIT_SECONDS, type=float,
+            help="Timeout in seconds for operations that call yb-admin and wait on the cluster")
+        self.parser.add_argument(
+            "--timeout-cluster-up", default=MAX_CLUSTER_UP_WAIT_SECONDS, type=float,
+            help="Timeout in seconds for operations that wait on the cluster to come up")
         self.parser.add_argument(
             "--verbose", action="store_true",
             help="If specified, will log internal debug messages to stderr.")
@@ -1041,7 +1046,7 @@ class ClusterControl:
             call_get_output_maybe_error(cmd, should_get_error)
             logging.info("Successfully modified placement info.")
             return True
-        if not retry_call_with_timeout(call_modify_placement_info, self.options.timeout):
+        if not retry_call_with_timeout(call_modify_placement_info, self.options.timeout_yb_admin):
             raise RuntimeError("Could not modify placement info for the cluster.")
 
     def get_number_of_servers(self, daemon_type):
@@ -1362,7 +1367,7 @@ class ClusterControl:
             call_get_output_maybe_error(cmd, should_get_error)
             return True
 
-        if not retry_call_with_timeout(call_change_config, self.options.timeout):
+        if not retry_call_with_timeout(call_change_config, self.options.timeout_yb_admin):
             raise ExitWithError("Could not change master config...")
 
     def dump_file_to_stderr(self, file_path):
@@ -1406,7 +1411,7 @@ class ClusterControl:
             return all(sum(pids.values(), []))
 
         logging.info("Waiting for master and tserver processes to come up.")
-        if not retry_call_with_timeout(call_check_for_processes, MAX_PROCESS_WAIT_SECONDS):
+        if not retry_call_with_timeout(call_check_for_processes, self.options.timeout_cluster_up):
             self.dump_missing_process_error_logs()
             logging.error("Failed waiting for master and tserver processes to come up.")
             return False
@@ -1466,7 +1471,7 @@ class ClusterControl:
                     num_yb_admin_ts, num_alive_ts))
 
         logging.info("Waiting for master leader election and tablet server registration.")
-        if not retry_call_with_timeout(call_check_for_ts, self.options.timeout):
+        if not retry_call_with_timeout(call_check_for_ts, self.options.timeout_yb_admin):
             logging.error("Failed waiting for {} tservers, got {}".format(
                 num_alive_ts, num_yb_admin_ts))
             return False

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1380,7 +1380,7 @@ class ClusterControl:
 
         def call_check_for_ts(should_get_error):
             if not call_check_for_processes(should_get_error):
-                raise RuntimeError("At least one master or tserver process is down.")
+                raise ExitWithError("At least one master or tserver process is down.")
 
             max_num_tservers = self.get_number_of_servers(DAEMON_TYPE_TSERVER)
             num_alive_ts = sum([self.get_pid(DaemonId(DAEMON_TYPE_TSERVER, i)) is not None

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1297,7 +1297,7 @@ class ClusterControl:
         self.stop_daemon(daemon_id)
         self.start_daemon(daemon_id)
 
-    def start_helper(self, server_counts_map):
+    def create_sanity_check(self, server_counts_map):
         if len(self.options.placement_info) > self.get_replication_factor():
             raise RuntimeError("Number of placement info fields is larger than "
                                "the replication factor and hence the number of servers.")
@@ -1325,9 +1325,6 @@ class ClusterControl:
                 "{}".format(pids))
         if any(sum(pids.values(), [])):
             raise ExitWithError("Processes are still up. Make sure to destroy old state.")
-
-        os.makedirs(self.options.cluster_base_dir)
-        self.for_all_daemons(self.start_daemon, server_counts_map)
 
     def change_config_if_master(self, daemon_id, cmd_type):
         if daemon_id.daemon_type == DAEMON_TYPE_TSERVER:
@@ -1569,7 +1566,9 @@ class ClusterControl:
             DAEMON_TYPE_TSERVER: server_counts
         }
 
-        self.start_helper(server_counts_map)
+        self.create_sanity_check(server_counts_map)
+        os.makedirs(self.options.cluster_base_dir)
+        self.for_all_daemons(self.start_daemon, server_counts_map)
         self.wait_for_cluster_or_raise()
         self.modify_placement_info()
 

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1250,7 +1250,7 @@ class ClusterControl:
         try:
             os.kill(pid, signal.SIGTERM)
         except OSError as e:
-            if e.errno == 3:
+            if e.errno == os.errno.ESRCH:
                 logging.info("{} does not exist; nothing to stop".format(name))
             else:
                 raise e
@@ -1303,7 +1303,7 @@ class ClusterControl:
         self.stop_daemon(daemon_id)
         self.start_daemon(daemon_id)
 
-    def create_ready_check(self):
+    def pre_create_checks(self):
         """
         Before moving forward with `create`, make a preliminary check to make sure things are ready.
         """
@@ -1364,7 +1364,7 @@ class ClusterControl:
 
         logging.info("Waiting for master and tserver processes to be up.")
         if not retry_call_with_timeout(call_check_for_processes, self.options.timeout):
-            logging.error("Not all master and tserver processes are up.")
+            logging.error("Failed waiting for master and tserver processes to come up.")
             return False
 
         # Wait for master leader to be ready, and wait for enough tservers.
@@ -1556,11 +1556,12 @@ class ClusterControl:
         :returns: return values of each function call.
         :rtype: dict
         """
-        fn_returns = {daemon_type: [] for daemon_type in DAEMON_TYPES}
+        fn_returns = dict()
         for daemon_type in DAEMON_TYPES:
             num_servers = self.get_number_of_servers(daemon_type)
             for daemon_index in range(1, num_servers + 1):
-                fn_returns[daemon_type].append(fn(DaemonId(daemon_type, daemon_index)))
+                fn_returns.setdefault(daemon_type, []).append(
+                    fn(DaemonId(daemon_type, daemon_index)))
         return fn_returns
 
     def create_cmd_impl(self):
@@ -1581,7 +1582,7 @@ class ClusterControl:
                 self.cluster_config[attr_name] = attr_value
         self.cluster_config['ports'] = self.options.base_ports
 
-        self.create_ready_check()
+        self.pre_create_checks()
         os.makedirs(self.options.cluster_base_dir)
         self.for_all_daemons(self.start_daemon)
         self.wait_for_cluster_or_raise()

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1329,8 +1329,8 @@ class ClusterControl:
 
         # Make sure that there are no master or tserver processes before the `create`.
         pids = self.for_all_daemons(self.get_pid)
-        logging.info("PIDs found: {}".format(pids))
         if any(sum(pids.values(), [])):
+            logging.info("PIDs found: {}".format(pids))
             raise ExitWithError("Processes are still up. Make sure to destroy old state.")
 
     def change_config_if_master(self, daemon_id, cmd_type):
@@ -1350,7 +1350,8 @@ class ClusterControl:
 
     def dump_missing_process_error_logs(self):
         pids = self.for_all_daemons(self.get_pid)
-        for daemon_type, pid_list in pids.items():
+        logging.info("PIDs found: {}".format(pids))
+        for daemon_type, pid_list in pids.iteritems():
             for index, pid in enumerate(pid_list, 1):
                 if pid is None:
                     daemon_id = DaemonId(daemon_type, index)
@@ -1365,6 +1366,9 @@ class ClusterControl:
                                 shutil.copyfileobj(log, sys.stderr.buffer)
                             else:
                                 shutil.copyfileobj(log, sys.stderr)
+                    else:
+                        print("Process {0} is down, and there is no corresponding error log at {1}".
+                              format(daemon_id, log_path), file=sys.stderr)
 
     def wait_for_cluster(self):
         """
@@ -1376,10 +1380,9 @@ class ClusterControl:
         # Wait for master and tserver processes to be ready.
         def call_check_for_processes(should_get_error):
             pids = self.for_all_daemons(self.get_pid)
-            logging.info("PIDs found: {}".format(pids))
             return all(sum(pids.values(), []))
 
-        logging.info("Waiting for master and tserver processes to be up.")
+        logging.info("Waiting for master and tserver processes to come up.")
         if not retry_call_with_timeout(call_check_for_processes, MAX_PROCESS_WAIT_SECONDS):
             self.dump_missing_process_error_logs()
             logging.error("Failed waiting for master and tserver processes to come up.")

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1303,7 +1303,7 @@ class ClusterControl:
         self.stop_daemon(daemon_id)
         self.start_daemon(daemon_id)
 
-    def create_sanity_check(self, server_counts_map):
+    def create_sanity_check(self):
         if len(self.options.placement_info) > self.get_replication_factor():
             raise RuntimeError("Number of placement info fields is larger than "
                                "the replication factor and hence the number of servers.")
@@ -1324,7 +1324,7 @@ class ClusterControl:
                     self.options.cluster_base_dir))
 
         # Make sure that there are no `yb-` processes before the `create`.
-        pids = self.for_all_daemons(self.get_pid, server_counts_map)
+        pids = self.for_all_daemons(self.get_pid)
         if self.args.verbose:
             logging.info(
                 "PIDs found when looking for daemons before starting daemons in `create`: "
@@ -1532,7 +1532,7 @@ class ClusterControl:
         title = "Node {}: {}".format(daemon_index, ", ".join(process_list))
         self.print_status_box(title, info_kv_list)
 
-    def for_all_daemons(self, fn, server_counts_map=None):
+    def for_all_daemons(self, fn):
         """
         Run the given function for all daemons.
 
@@ -1540,11 +1540,7 @@ class ClusterControl:
         """
         fn_returns = {daemon_type: [] for daemon_type in DAEMON_TYPES}
         for daemon_type in DAEMON_TYPES:
-            if server_counts_map:
-                num_servers = server_counts_map[daemon_type]
-            else:
-                num_servers = self.get_number_of_servers(daemon_type)
-
+            num_servers = self.get_number_of_servers(daemon_type)
             for daemon_index in range(1, num_servers + 1):
                 fn_returns[daemon_type].append(fn(DaemonId(daemon_type, daemon_index)))
         return fn_returns
@@ -1567,14 +1563,9 @@ class ClusterControl:
                 self.cluster_config[attr_name] = attr_value
         self.cluster_config['ports'] = self.options.base_ports
 
-        server_counts_map = {
-            DAEMON_TYPE_MASTER: server_counts,
-            DAEMON_TYPE_TSERVER: server_counts
-        }
-
-        self.create_sanity_check(server_counts_map)
+        self.create_sanity_check()
         os.makedirs(self.options.cluster_base_dir)
-        self.for_all_daemons(self.start_daemon, server_counts_map)
+        self.for_all_daemons(self.start_daemon)
         self.wait_for_cluster_or_raise()
         self.modify_placement_info()
 

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -106,8 +106,8 @@ YEDIS_DEFAULT_PORT = 6379
 LOCALHOST_IP = '127.0.0.1'
 
 SLEEP_TIME_IN_SEC = 1
-MAX_YB_ADMIN_WAIT_SECONDS = 45
-MAX_CLUSTER_UP_WAIT_SECONDS = 10
+MAX_YB_ADMIN_WAIT_SEC = 45
+MAX_WAIT_FOR_PROCESSES_RUNNING_SEC = 10
 DEFAULT_REPLICATION_FACTOR = 1
 
 # A regex to get data directories out a command line of a running process.
@@ -135,7 +135,7 @@ def call_get_output_maybe_error(cmd_list, should_get_error=False):
         return output
 
 
-def retry_call_with_timeout(fn, timeout_sec=MAX_YB_ADMIN_WAIT_SECONDS):
+def retry_call_with_timeout(fn, timeout_sec=MAX_YB_ADMIN_WAIT_SEC):
     """
     This will retry a given function that is supposed to be doing subprocess callouts. Based on
     the passed in function behavior, this function will behave accordingly:
@@ -541,8 +541,8 @@ class ClusterOptions:
     def __init__(self):
         self.max_daemon_index = 20
         self.num_shards_per_tserver = None
-        self.timeout_yb_admin = None
-        self.timeout_cluster_up = None
+        self.timeout_yb_admin_sec = None
+        self.timeout_processes_running_sec = None
 
         self.cluster_base_dir = None
 
@@ -624,8 +624,8 @@ class ClusterOptions:
         self.custom_binary_dir = args.binary_dir
         self.cluster_base_dir = args.data_dir
         self.num_shards_per_tserver = args.num_shards_per_tserver
-        self.timeout_yb_admin = args.timeout_yb_admin
-        self.timeout_cluster_up = args.timeout_cluster_up
+        self.timeout_yb_admin_sec = args.timeout_yb_admin_sec
+        self.timeout_processes_running_sec = args.timeout_processes_running_sec
 
         if hasattr(args, "v"):
             self.verbose_level = args.v
@@ -927,11 +927,13 @@ class ClusterControl:
             "--num_shards_per_tserver", default=2, type=int,
             help="Number of shards (tablets) to start per tablet server for each table.")
         self.parser.add_argument(
-            "--timeout-yb-admin", default=MAX_YB_ADMIN_WAIT_SECONDS, type=float,
-            help="Timeout in seconds for operations that call yb-admin and wait on the cluster")
+            "--timeout-yb-admin-sec", default=MAX_YB_ADMIN_WAIT_SEC, type=float,
+            help="Timeout in seconds for operations that call yb-admin and wait on the cluster.")
         self.parser.add_argument(
-            "--timeout-cluster-up", default=MAX_CLUSTER_UP_WAIT_SECONDS, type=float,
-            help="Timeout in seconds for operations that wait on the cluster to come up")
+            "--timeout-processes-running-sec", default=MAX_WAIT_FOR_PROCESSES_RUNNING_SEC,
+            type=float,
+            help="Timeout in seconds for operations that wait on the master and tserver processes "
+                 "to come up and start running.")
         self.parser.add_argument(
             "--verbose", action="store_true",
             help="If specified, will log internal debug messages to stderr.")
@@ -1046,7 +1048,8 @@ class ClusterControl:
             call_get_output_maybe_error(cmd, should_get_error)
             logging.info("Successfully modified placement info.")
             return True
-        if not retry_call_with_timeout(call_modify_placement_info, self.options.timeout_yb_admin):
+        if not retry_call_with_timeout(call_modify_placement_info,
+                                       self.options.timeout_yb_admin_sec):
             raise RuntimeError("Could not modify placement info for the cluster.")
 
     def get_number_of_servers(self, daemon_type):
@@ -1367,7 +1370,7 @@ class ClusterControl:
             call_get_output_maybe_error(cmd, should_get_error)
             return True
 
-        if not retry_call_with_timeout(call_change_config, self.options.timeout_yb_admin):
+        if not retry_call_with_timeout(call_change_config, self.options.timeout_yb_admin_sec):
             raise ExitWithError("Could not change master config...")
 
     def dump_file_to_stderr(self, file_path):
@@ -1411,7 +1414,8 @@ class ClusterControl:
             return all(sum(pids.values(), []))
 
         logging.info("Waiting for master and tserver processes to come up.")
-        if not retry_call_with_timeout(call_check_for_processes, self.options.timeout_cluster_up):
+        if not retry_call_with_timeout(call_check_for_processes,
+                                       self.options.timeout_processes_running_sec):
             self.dump_missing_process_error_logs()
             logging.error("Failed waiting for master and tserver processes to come up.")
             return False
@@ -1471,7 +1475,7 @@ class ClusterControl:
                     num_yb_admin_ts, num_alive_ts))
 
         logging.info("Waiting for master leader election and tablet server registration.")
-        if not retry_call_with_timeout(call_check_for_ts, self.options.timeout_yb_admin):
+        if not retry_call_with_timeout(call_check_for_ts, self.options.timeout_yb_admin_sec):
             logging.error("Failed waiting for {} tservers, got {}".format(
                 num_alive_ts, num_yb_admin_ts))
             return False

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1354,6 +1354,20 @@ class ClusterControl:
         alive (based on valid PID), then this function returns True. Anything else will end up
         returning False.
         """
+        # Wait for master and tserver processes to be ready.
+        def call_check_for_processes(should_get_error):
+            pids = self.for_all_daemons(self.get_pid)
+            if self.args.verbose:
+                logging.info(
+                    "PIDs found when looking for daemons after starting daemons in `create`: "
+                    "{}".format(pids))
+            return all(sum(pids.values(), []))
+
+        logging.info("Waiting for master and tserver processes to be up.")
+        if not retry_call_with_timeout(call_check_for_processes, self.options.timeout):
+            logging.error("Not all master and tserver processes are up.")
+            return False
+
         # Wait for master leader to be ready, and wait for enough tservers.
         # 'Enough' here means that the number of live tservers reported to the master should be
         # equal to the number of TS we have started -- based on directories we have on the FS.
@@ -1369,6 +1383,9 @@ class ClusterControl:
         num_yb_admin_ts = None
 
         def call_check_for_ts(should_get_error):
+            if not call_check_for_processes(should_get_error):
+                raise RuntimeError("At least one master or tserver process is down.")
+
             max_num_tservers = self.get_number_of_servers(DAEMON_TYPE_TSERVER)
             num_alive_ts = sum([self.get_pid(DaemonId(DAEMON_TYPE_TSERVER, i)) is not None
                                 for i in range(1, max_num_tservers + 1)])
@@ -1409,6 +1426,7 @@ class ClusterControl:
             logging.error("Failed waiting for {} tservers, got {}".format(
                 num_alive_ts, num_yb_admin_ts))
             return False
+
         return True
 
     def wait_for_cluster_or_raise(self):

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1303,7 +1303,10 @@ class ClusterControl:
         self.stop_daemon(daemon_id)
         self.start_daemon(daemon_id)
 
-    def create_sanity_check(self):
+    def create_ready_check(self):
+        """
+        Before moving forward with `create`, make a preliminary check to make sure things are ready.
+        """
         if len(self.options.placement_info) > self.get_replication_factor():
             raise RuntimeError("Number of placement info fields is larger than "
                                "the replication factor and hence the number of servers.")
@@ -1578,7 +1581,7 @@ class ClusterControl:
                 self.cluster_config[attr_name] = attr_value
         self.cluster_config['ports'] = self.options.base_ports
 
-        self.create_sanity_check()
+        self.create_ready_check()
         os.makedirs(self.options.cluster_base_dir)
         self.for_all_daemons(self.start_daemon)
         self.wait_for_cluster_or_raise()

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -878,6 +878,24 @@ class ClusterControl:
         return ["{}/node-{}/{}".format(self.options.cluster_base_dir, daemon_index, drive)
                 for drive in self.get_drive_paths()]
 
+    def get_log_path(self, daemon_id, is_err=True):
+        """
+        Get the out or error log path for a daemon.  A log file may not necessarily exist at the
+        returned path.
+
+        :param daemon_id: daemon to get the log path for
+        :type daemon_id: :class:`DaemonId`
+        :param is_err: whether to get the error log path rather than the out log path
+        :type is_err: bool
+        :returns: path to the specified out or error log of the specified daemon
+        :rtype: str
+        """
+        node_base_dirs = self.get_base_node_dirs(daemon_id.index)
+        first_base_dir = node_base_dirs[0]
+        extension = "err" if is_err else "out"
+        log_name = "{0}.{1}".format(daemon_id.daemon_type, extension)
+        return os.path.join(first_base_dir, log_name)
+
     @staticmethod
     def add_extra_flags_arguments(subparser):
         subparser.add_argument(
@@ -1120,7 +1138,6 @@ class ClusterControl:
 
     def build_command(self, daemon_id, specific_arg_list):
         node_base_dirs = self.get_base_node_dirs(daemon_id.index)
-        first_base_dir = node_base_dirs[0]
 
         binary_path = self.options.get_server_binary_path(daemon_id.daemon_type)
         command_list = [
@@ -1149,8 +1166,8 @@ class ClusterControl:
         command_list.extend(specific_arg_list)
 
         # Redirect out and err and launch in the background
-        command_list.append(">\"{0}/{1}.out\" 2>\"{0}/{1}.err\" &".format(
-            first_base_dir, daemon_id.daemon_type))
+        command_list.append(">\"{0}\" 2>\"{1}\" &".format(
+            self.get_log_path(daemon_id, is_err=False), self.get_log_path(daemon_id, is_err=True)))
         return " ".join(command_list)
 
     @staticmethod
@@ -1348,6 +1365,20 @@ class ClusterControl:
         if not retry_call_with_timeout(call_change_config, self.options.timeout):
             raise ExitWithError("Could not change master config...")
 
+    def keep_and_dump_log(self, log_path):
+        """
+        Keeps log file intact and dumps log file contents to STDERR.
+
+        :param log_path: path to the log file, assumed to exist
+        :type log_path: str
+        """
+        print("Viewing log at {}:".format(log_path), file=sys.stderr)
+        with open(log_path, "rb") as log:
+            if sys.version_info[0] >= 3:
+                shutil.copyfileobj(log, sys.stderr.buffer)
+            else:
+                shutil.copyfileobj(log, sys.stderr)
+
     def dump_missing_process_error_logs(self):
         pids = self.for_all_daemons(self.get_pid)
         logging.info("PIDs found: {}".format(pids))
@@ -1355,17 +1386,9 @@ class ClusterControl:
             for index, pid in enumerate(pid_list, 1):
                 if pid is None:
                     daemon_id = DaemonId(daemon_type, index)
-                    node_base_dirs = self.get_base_node_dirs(daemon_id.index)
-                    first_base_dir = node_base_dirs[0]
-                    log_name = daemon_id.daemon_type + ".err"
-                    log_path = os.path.join(first_base_dir, log_name)
+                    log_path = self.get_log_path(daemon_id)
                     if os.path.exists(log_path):
-                        with open(log_path) as log:
-                            print("Viewing log at {}:".format(log_path), file=sys.stderr)
-                            if sys.version_info[0] >= 3:
-                                shutil.copyfileobj(log, sys.stderr.buffer)
-                            else:
-                                shutil.copyfileobj(log, sys.stderr)
+                        self.keep_and_dump_log(log_path)
                     else:
                         print("Process {0} is down, and there is no corresponding error log at {1}".
                               format(daemon_id, log_path), file=sys.stderr)
@@ -1830,11 +1853,7 @@ class ClusterControl:
         if os.path.isfile(self.log_file):
             # If we called the atexit handler and we have a file, it means we must have had errors.
             if keep_log_file_and_dump_to_stderr:
-                with open(self.log_file, "rb") as log:
-                    if sys.version_info[0] >= 3:
-                        shutil.copyfileobj(log, sys.stderr.buffer)
-                    else:
-                        shutil.copyfileobj(log, sys.stderr)
+                self.keep_and_dump_log(self.log_file)
                 print("^^^ Encountered errors ^^^")
             # Whichever cleanup comes first should remove the file.
             # TODO: Maybe keep the log file around and allow the user to upload a gist with the log.

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1323,12 +1323,10 @@ class ClusterControl:
                  "Use --data_dir to specify a different data directory.").format(
                     self.options.cluster_base_dir))
 
-        # Make sure that there are no `yb-` processes before the `create`.
+        # Make sure that there are no master or tserver processes before the `create`.
         pids = self.for_all_daemons(self.get_pid)
         if self.args.verbose:
-            logging.info(
-                "PIDs found when looking for daemons before starting daemons in `create`: "
-                "{}".format(pids))
+            logging.info("Daemon PIDs found before starting daemons in `create`: {}".format(pids))
         if any(sum(pids.values(), [])):
             raise ExitWithError("Processes are still up. Make sure to destroy old state.")
 
@@ -1358,9 +1356,7 @@ class ClusterControl:
         def call_check_for_processes(should_get_error):
             pids = self.for_all_daemons(self.get_pid)
             if self.args.verbose:
-                logging.info(
-                    "PIDs found when looking for daemons after starting daemons in `create`: "
-                    "{}".format(pids))
+                logging.info("Daemon PIDs found after starting daemons: {}".format(pids))
             return all(sum(pids.values(), []))
 
         logging.info("Waiting for master and tserver processes to be up.")
@@ -1554,7 +1550,8 @@ class ClusterControl:
         """
         Run the given function for all daemons.
 
-        Returns the return values of each function call.
+        :returns: return values of each function call.
+        :rtype: dict
         """
         fn_returns = {daemon_type: [] for daemon_type in DAEMON_TYPES}
         for daemon_type in DAEMON_TYPES:

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1328,8 +1328,7 @@ class ClusterControl:
 
         # Make sure that there are no master or tserver processes before the `create`.
         pids = self.for_all_daemons(self.get_pid)
-        if self.args.verbose:
-            logging.info("Daemon PIDs found before starting daemons in `create`: {}".format(pids))
+        logging.info("PIDs found: {}".format(pids))
         if any(sum(pids.values(), [])):
             raise ExitWithError("Processes are still up. Make sure to destroy old state.")
 
@@ -1376,8 +1375,7 @@ class ClusterControl:
         # Wait for master and tserver processes to be ready.
         def call_check_for_processes(should_get_error):
             pids = self.for_all_daemons(self.get_pid)
-            if self.args.verbose:
-                logging.info("Daemon PIDs found after starting daemons: {}".format(pids))
+            logging.info("PIDs found: {}".format(pids))
             return all(sum(pids.values(), []))
 
         logging.info("Waiting for master and tserver processes to be up.")

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -68,11 +68,11 @@ start_cluster_run_tests() {
     fatal "One arg expected: root directory to run in"
   fi
   local root_dir=$1
-  ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" start "$create_flags" )
+  ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" start $create_flags )
   verify_ysqlsh
   (
     set -x
-    "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" add_node "$create_flags"
+    "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" add_node $create_flags
   )
   verify_ysqlsh
   ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" stop_node 1 )
@@ -86,7 +86,7 @@ start_cluster_run_tests() {
   fi
   (
     set -x
-    "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" start_node 1 "$create_flags"
+    "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" start_node 1 $create_flags
   )
   verify_ysqlsh
   ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" stop )
@@ -254,7 +254,7 @@ trap cleanup EXIT
 log_heading "Running basic tests"
 (
   set -x
-  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" --install-if-needed create "$create_flags"
+  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" --install-if-needed create $create_flags
 )
 
 detect_installation_dir
@@ -273,7 +273,7 @@ custom_ysql_port=54320
 (
   set -x
   "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" create --ysql_port "$custom_ysql_port" \
-      "$create_flags"
+      $create_flags
 )
 verify_ysqlsh 1 "$custom_ysql_port"
 (
@@ -283,7 +283,7 @@ verify_ysqlsh 1 "$custom_ysql_port"
 log "Checking that the custom YSQL port persists across restarts"
 (
   set -x
-  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" start "$create_flags"
+  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" start $create_flags
 )
 verify_ysqlsh 1 "$custom_ysql_port"
 (
@@ -314,7 +314,7 @@ fi
 (
   set -x
   installation_dir=$yb_build_root
-  "$python_interpreter" "$submodule_bin_dir/yb-ctl" "${yb_ctl_args[@]}" start "$create_flags"
+  "$python_interpreter" "$submodule_bin_dir/yb-ctl" "${yb_ctl_args[@]}" start $create_flags
 )
 verify_ysqlsh
 (

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -99,7 +99,7 @@ yb_ctl_args=(
   --data_dir "$yb_data_dir"
 )
 
-create_flags="--tserver_flags=v=1"
+create_flags=""
 
 thick_log_heading() {
   (

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -235,6 +235,15 @@ log "OSTYPE: $OSTYPE"
 log "USER: $USER"
 log "TRAVIS: ${TRAVIS:-undefined}"
 
+if [[ ${TRAVIS:-} == "true" && $OSTYPE == darwin* ]]; then
+  sudo ifconfig lo0 alias 127.0.0.2
+  sudo ifconfig lo0 alias 127.0.0.3
+  sudo ifconfig lo0 alias 127.0.0.4
+  sudo ifconfig lo0 alias 127.0.0.5
+  sudo ifconfig lo0 alias 127.0.0.6
+  sudo ifconfig lo0 alias 127.0.0.7
+fi
+
 if [[ ${TRAVIS:-} != "true" || $OSTYPE != darwin* ]]; then
   # We don't run pycodestyle on macOS on Travis CI.
   pycodestyle --config=pycodestyle.conf bin/yb-ctl

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -68,9 +68,12 @@ start_cluster_run_tests() {
     fatal "One arg expected: root directory to run in"
   fi
   local root_dir=$1
-  ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" start )
+  ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" start "$create_flags" )
   verify_ysqlsh
-  ( set -x;  "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" add_node )
+  (
+    set -x
+    "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" add_node "$create_flags"
+  )
   verify_ysqlsh
   ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" stop_node 1 )
 
@@ -81,7 +84,10 @@ start_cluster_run_tests() {
   if false; then
     verify_ysqlsh 2
   fi
-  ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" start_node 1 )
+  (
+    set -x
+    "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" start_node 1 "$create_flags"
+  )
   verify_ysqlsh
   ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" stop )
   ( set -x; "$python_interpreter" "$root_dir"/yb-ctl "${yb_ctl_args[@]}" destroy )
@@ -92,6 +98,8 @@ readonly yb_data_dir="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM
 yb_ctl_args=(
   --data_dir "$yb_data_dir"
 )
+
+create_flags="--tserver_flags=v=1"
 
 thick_log_heading() {
   (
@@ -237,7 +245,7 @@ trap cleanup EXIT
 log_heading "Running basic tests"
 (
   set -x
-  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" --install-if-needed create
+  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" --install-if-needed create "$create_flags"
 )
 
 detect_installation_dir
@@ -255,7 +263,8 @@ log_heading "Testing YSQL port override"
 custom_ysql_port=54320
 (
   set -x
-  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" create --ysql_port "$custom_ysql_port"
+  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" create --ysql_port "$custom_ysql_port" \
+      "$create_flags"
 )
 verify_ysqlsh 1 "$custom_ysql_port"
 (
@@ -265,7 +274,7 @@ verify_ysqlsh 1 "$custom_ysql_port"
 log "Checking that the custom YSQL port persists across restarts"
 (
   set -x
-  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" start
+  "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" start "$create_flags"
 )
 verify_ysqlsh 1 "$custom_ysql_port"
 (
@@ -296,7 +305,7 @@ fi
 (
   set -x
   installation_dir=$yb_build_root
-  "$python_interpreter" "$submodule_bin_dir/yb-ctl" "${yb_ctl_args[@]}" start
+  "$python_interpreter" "$submodule_bin_dir/yb-ctl" "${yb_ctl_args[@]}" start "$create_flags"
 )
 verify_ysqlsh
 (

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -235,6 +235,8 @@ log "OSTYPE: $OSTYPE"
 log "USER: $USER"
 log "TRAVIS: ${TRAVIS:-undefined}"
 
+# Mac needs loopback aliases explicitly created:
+#   https://docs.yugabyte.com/latest/quick-start/install/
 if [[ ${TRAVIS:-} == "true" && $OSTYPE == darwin* ]]; then
   sudo ifconfig lo0 alias 127.0.0.2
   sudo ifconfig lo0 alias 127.0.0.3


### PR DESCRIPTION
Resolves YugaByte/yugabyte-db#1643 and YugaByte/yugabyte-db#1729.

For `yb-ctl`, add various process existence checks:
* Ensure that no master or tserver processes exist at the beginning of
  performing a `create`: added in `ClusterControl.pre_create_checks`
* Ensure that master and tserver processes exist after
  `ClusterControl.start_daemon`s when performing a `create` or `start`:
  addressed by `call_check_for_processes` in
  `ClusterControl.wait_for_cluster`
* Ensure that master and tserver processes continue to exist while
  performing calls to yb-admin in `ClusterControl.wait_for_cluster`:
  addressed by `call_check_for_processes` in `call_check_for_ts`
* Allow PIDs referenced by `postmaster.pid` to refer to already dead
  postgres processes: added in `ClusterControl.stop_process`