### PR TITLE
Fix JDBC URL

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1534,7 +1534,7 @@ class ClusterControl:
                 YSQL_DEFAULT_PORT)
 
             info_kv_list.extend([
-                ("JDBC", "postgresql://postgres@{}:{}".format(
+                ("JDBC", "jdbc:postgresql://{}:{}/postgres".format(
                     tserver_ip_address, ysql_port)),
                 ("YSQL Shell", ysqlsh_cmd_line)
             ])


### PR DESCRIPTION
Change the JDBC URL format shown in yb-ctl status from the incorrect
postgresql://postgres@127.0.0.1:5433 format to the correct
jdbc:postgresql://127.0.0.1:5433/postgres format.

Closes YugaByte/yugabyte-db#1907.