### PR TITLE
yb-ctl should allow flags at end of command

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -539,6 +539,7 @@ class ClusterOptions:
     def __init__(self):
         self.max_daemon_index = 20
         self.num_shards_per_tserver = None
+        self.ysql_num_shards_per_tserver = None
         self.timeout_yb_admin_sec = None
         self.timeout_processes_running_sec = None
 
@@ -623,6 +624,7 @@ class ClusterOptions:
         self.custom_binary_dir = args.binary_dir
         self.cluster_base_dir = args.data_dir
         self.num_shards_per_tserver = args.num_shards_per_tserver
+        self.ysql_num_shards_per_tserver = args.ysql_num_shards_per_tserver
         self.timeout_yb_admin_sec = args.timeout_yb_admin_sec
         self.timeout_processes_running_sec = args.timeout_processes_running_sec
 
@@ -934,7 +936,10 @@ class ClusterControl:
             help="Replication factor for the cluster as well as default number of masters. ")
         self.parser.add_argument(
             "--num_shards_per_tserver", default=2, type=int,
-            help="Number of shards (tablets) to start per tablet server for each table.")
+            help="Number of shards (tablets) to start per tablet server for each non-YSQL table.")
+        self.parser.add_argument(
+            "--ysql_num_shards_per_tserver", default=2, type=int,
+            help="Number of shards (tablets) to start per tablet server for each YSQL table.")
         self.parser.add_argument(
             "--timeout-yb-admin-sec", default=MAX_YB_ADMIN_WAIT_SEC, type=float,
             help="Timeout in seconds for operations that call yb-admin and wait on the cluster.")
@@ -1201,7 +1206,8 @@ class ClusterControl:
     def get_master_only_flags(self, daemon_id):
         command_list = [
             "--replication_factor={}".format(self.get_replication_factor()),
-            "--yb_num_shards_per_tserver {}".format(self.options.num_shards_per_tserver)
+            "--yb_num_shards_per_tserver {}".format(self.options.num_shards_per_tserver),
+            "--ysql_num_shards_per_tserver={}".format(self.options.ysql_num_shards_per_tserver)
         ]
 
         if not self.options.is_shell_master:
@@ -1223,7 +1229,8 @@ class ClusterControl:
             "--local_ip_for_outbound_sockets=" + self.options.get_ip_address(daemon_id),
             # TODO ENG-2876: Enable this in master as well.
             "--use_cassandra_authentication={}".format(
-                str(self.options.use_cassandra_authentication).lower())
+                str(self.options.use_cassandra_authentication).lower()),
+            "--ysql_num_shards_per_tserver={}".format(self.options.ysql_num_shards_per_tserver)
         ]
         if self.is_ysql_enabled():
             command_list += [

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -334,11 +334,11 @@ def remove_surrounding_quotes(s):
 
 
 class Installer:
-    YUGABYTE_DB_VERSION = '1.2.11.0'
-    DOWNLOAD_URL_PATTERN = 'https://downloads.yugabyte.com/yugabyte-ce-{version}-{os}.tar.gz'
+    YUGABYTE_DB_VERSION = '1.3.2.1'
+    DOWNLOAD_URL_PATTERN = 'https://downloads.yugabyte.com/yugabyte-{version}-{os}.tar.gz'
     SHA256_SUM_BY_OS = {
-        'darwin': 'acb5982072347d8cff9742c85d0affd3dd9d86a4fa809f7a91058945a2771b50',
-        'linux': '97de55a5d4353c17eb9b8941c56ed1032fa21f98d991d953c6db47cb54659917'
+        'darwin': 'b1bbdc5d2a679757fd8f8c70f2f01b48d29e725b101c24ad32063ab3ffbffbf7',
+        'linux': '233b138ab75c8c7881d4da015982d84bce62e8ef08b56a37ecd437582ca68f72'
     }
 
     def __init__(self, only_find_existing=False):
@@ -368,7 +368,7 @@ class Installer:
                 logging.error(
                     "Directory %s exists but does not appear to be a valid YugaByte DB "
                     "installation directory. Remove that directory and re-run the script "
-                    "to re-install YugaByte DB.", installation_dir)
+                    "to re-install YugaByte DB.", self.installation_dir)
                 sys.exit(1)
             # Already installed.
             logging.info("Found existing YugaByte DB installation at %s", self.installation_dir)

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -866,7 +866,8 @@ class ClusterControl:
                  "to come up and start running.")
         self.parent_parser.add_argument(
             "--verbose", action="store_true",
-            help="If specified, will log internal debug messages to stderr.")
+            help="If specified, will log internal debug messages to stderr. Note --verbose "
+                 "affects yb-ctl and --v affects server processes.")
         self.parent_parser.add_argument(
             "--install-if-needed",
             action='store_true',
@@ -1007,9 +1008,10 @@ class ClusterControl:
                                          "in case you would want to pass more than one value.")
 
             subparsers[cmd].add_argument("--v", default=0, choices=[str(i) for i in range(5)],
-                                         help="Specify the verbosity which dictates "
-                                         "the amount of logging on servers trace files."
-                                         "Default is 0 and maximum is 4.")
+                                         help="Specify the verbosity of server processes, which "
+                                         "dictates the amount of logging on servers trace files. "
+                                         "Note --verbose affects yb-ctl and --v affects server "
+                                         "processes. Default is 0 and maximum is 4.")
 
             subparsers[cmd].add_argument("--use_cassandra_authentication",
                                          action='store_true',

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -813,10 +813,11 @@ class ClusterControl:
         self.options = ClusterOptions()
         self.args = None
 
-        self.parser = argparse.ArgumentParser()
-        self.subparsers = self.parser.add_subparsers()
         # Parent subparser holding all common flags.
         self.parent_parser = argparse.ArgumentParser(add_help=False)
+        self.setup_parent_parser()
+        self.parser = argparse.ArgumentParser(parents=[self.parent_parser])
+        self.subparsers = self.parser.add_subparsers()
 
         # This is a dictionary serialized into JSON and written to a configuration file in the data
         # directory.
@@ -836,6 +837,41 @@ class ClusterControl:
             raise RuntimeError("Invalid command: {}".format(command))
         subparser.set_defaults(func=func)
         return subparser
+
+    # TODO: Combine this with setup_parsing when we drop support for `yb-ctl --rf 3 create` so
+    # self.parser doesn't require a parent parser.
+    def setup_parent_parser(self):
+        self.parent_parser.add_argument(
+            "--binary_dir", default=None,
+            help="Specify a custom directory in which to find the yugabyte binaries.")
+        self.parent_parser.add_argument(
+            "--data_dir", default=get_default_data_dir(),
+            help="Specify a custom directory where to store data.")
+        self.parent_parser.add_argument(
+            "--replication_factor", "--rf", default=DEFAULT_REPLICATION_FACTOR, type=int,
+            help="Replication factor for the cluster as well as default number of masters. ")
+        self.parent_parser.add_argument(
+            "--num_shards_per_tserver", default=2, type=int,
+            help="Number of shards (tablets) to start per tablet server for each non-YSQL table.")
+        self.parent_parser.add_argument(
+            "--ysql_num_shards_per_tserver", default=2, type=int,
+            help="Number of shards (tablets) to start per tablet server for each YSQL table.")
+        self.parent_parser.add_argument(
+            "--timeout-yb-admin-sec", default=MAX_YB_ADMIN_WAIT_SEC, type=float,
+            help="Timeout in seconds for operations that call yb-admin and wait on the cluster.")
+        self.parent_parser.add_argument(
+            "--timeout-processes-running-sec", default=MAX_WAIT_FOR_PROCESSES_RUNNING_SEC,
+            type=float,
+            help="Timeout in seconds for operations that wait on the master and tserver processes "
+                 "to come up and start running.")
+        self.parent_parser.add_argument(
+            "--verbose", action="store_true",
+            help="If specified, will log internal debug messages to stderr.")
+        self.parent_parser.add_argument(
+            "--install-if-needed",
+            action='store_true',
+            help="With this option, if YugaByte DB is not yet installed on the system, the latest "
+                 "version will be downloaded and installed automatically.")
 
     def get_cluster_config_file_path(self):
         """
@@ -927,39 +963,6 @@ class ClusterControl:
         """
         Sets up the command-line parser. Called from the constructor.
         """
-        self.parent_parser.add_argument(
-            "--binary_dir", default=None,
-            help="Specify a custom directory in which to find the yugabyte binaries.")
-        self.parent_parser.add_argument(
-            "--data_dir", default=get_default_data_dir(),
-            help="Specify a custom directory where to store data.")
-        self.parent_parser.add_argument(
-            "--replication_factor", "--rf", default=DEFAULT_REPLICATION_FACTOR, type=int,
-            help="Replication factor for the cluster as well as default number of masters. ")
-        self.parent_parser.add_argument(
-            "--num_shards_per_tserver", default=2, type=int,
-            help="Number of shards (tablets) to start per tablet server for each non-YSQL table.")
-        self.parent_parser.add_argument(
-            "--ysql_num_shards_per_tserver", default=2, type=int,
-            help="Number of shards (tablets) to start per tablet server for each YSQL table.")
-        self.parent_parser.add_argument(
-            "--timeout-yb-admin-sec", default=MAX_YB_ADMIN_WAIT_SEC, type=float,
-            help="Timeout in seconds for operations that call yb-admin and wait on the cluster.")
-        self.parent_parser.add_argument(
-            "--timeout-processes-running-sec", default=MAX_WAIT_FOR_PROCESSES_RUNNING_SEC,
-            type=float,
-            help="Timeout in seconds for operations that wait on the master and tserver processes "
-                 "to come up and start running.")
-        self.parent_parser.add_argument(
-            "--verbose", action="store_true",
-            help="If specified, will log internal debug messages to stderr.")
-
-        self.parent_parser.add_argument(
-            "--install-if-needed",
-            action='store_true',
-            help="With this option, if YugaByte DB is not yet installed on the system, the latest "
-                 "version will be downloaded and installed automatically.")
-
         subparsers = {}
         for cmd_name, help in (
                 ("create", "Create a new cluster"),

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -815,6 +815,8 @@ class ClusterControl:
 
         self.parser = argparse.ArgumentParser()
         self.subparsers = self.parser.add_subparsers()
+        # Parent subparser holding all common flags.
+        self.parent_parser = argparse.ArgumentParser(add_help=False)
 
         # This is a dictionary serialized into JSON and written to a configuration file in the data
         # directory.
@@ -828,7 +830,7 @@ class ClusterControl:
         self.already_running_daemons = set()
 
     def setup_base_parser(self, command, help=None):
-        subparser = self.subparsers.add_parser(command, help=help)
+        subparser = self.subparsers.add_parser(command, help=help, parents=[self.parent_parser])
         func = getattr(self, "%s_cmd_impl" % command, None)
         if not func:
             raise RuntimeError("Invalid command: {}".format(command))
@@ -925,34 +927,34 @@ class ClusterControl:
         """
         Sets up the command-line parser. Called from the constructor.
         """
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--binary_dir", default=None,
             help="Specify a custom directory in which to find the yugabyte binaries.")
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--data_dir", default=get_default_data_dir(),
             help="Specify a custom directory where to store data.")
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--replication_factor", "--rf", default=DEFAULT_REPLICATION_FACTOR, type=int,
             help="Replication factor for the cluster as well as default number of masters. ")
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--num_shards_per_tserver", default=2, type=int,
             help="Number of shards (tablets) to start per tablet server for each non-YSQL table.")
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--ysql_num_shards_per_tserver", default=2, type=int,
             help="Number of shards (tablets) to start per tablet server for each YSQL table.")
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--timeout-yb-admin-sec", default=MAX_YB_ADMIN_WAIT_SEC, type=float,
             help="Timeout in seconds for operations that call yb-admin and wait on the cluster.")
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--timeout-processes-running-sec", default=MAX_WAIT_FOR_PROCESSES_RUNNING_SEC,
             type=float,
             help="Timeout in seconds for operations that wait on the master and tserver processes "
                  "to come up and start running.")
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--verbose", action="store_true",
             help="If specified, will log internal debug messages to stderr.")
 
-        self.parser.add_argument(
+        self.parent_parser.add_argument(
             "--install-if-needed",
             action='store_true',
             help="With this option, if YugaByte DB is not yet installed on the system, the latest "

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -301,45 +301,6 @@ data_dir_1="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-1"
 )
 verify_ysqlsh
 
-log_heading "Creating second universe with custom ip_start"
-custom_ip_start=20
-data_dir_2="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-2"
-(
-  set -x
-  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" create $create_flags \
-      --ip_start "$custom_ip_start"
-)
-verify_ysqlsh "$custom_ip_start"
-
-(
-  set -x
-  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" stop
-)
-(
-  set -x
-  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" stop
-)
-
-log "Checking that the universes and custom ip addresses persist across restarts"
-(
-  set -x
-  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" start $create_flags
-)
-(
-  set -x
-  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" start $create_flags
-)
-verify_ysqlsh
-verify_ysqlsh "$custom_ip_start"
-(
-  set -x
-  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" destroy
-)
-(
-  set -x
-  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" destroy
-)
-
 # -------------------------------------------------------------------------------------------------
 log_heading "Testing putting this version of yb-ctl inside the installation directory"
 ( set -x; cp bin/yb-ctl "$installation_dir" )

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -293,52 +293,52 @@ verify_ysqlsh 1 "$custom_ysql_port"
   "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" destroy
 )
 
-# log_heading "Test creating multiple universes"
-# data_dir_1="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-1"
-# (
-#   set -x
-#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" create $create_flags
-# )
-# verify_ysqlsh
+log_heading "Test creating multiple universes"
+data_dir_1="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-1"
+(
+  set -x
+  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" create $create_flags
+)
+verify_ysqlsh
 
-# log_heading "Creating second universe with custom ip_start"
-# custom_ip_start=20
-# data_dir_2="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-2"
-# (
-#   set -x
-#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" create $create_flags \
-#       --ip_start "$custom_ip_start"
-# )
-# verify_ysqlsh "$custom_ip_start"
+log_heading "Creating second universe with custom ip_start"
+custom_ip_start=20
+data_dir_2="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-2"
+(
+  set -x
+  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" create $create_flags \
+      --ip_start "$custom_ip_start"
+)
+verify_ysqlsh "$custom_ip_start"
 
-# (
-#   set -x
-#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" stop
-# )
-# (
-#   set -x
-#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" stop
-# )
+(
+  set -x
+  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" stop
+)
+(
+  set -x
+  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" stop
+)
 
-# log "Checking that the universes and custom ip addresses persist across restarts"
-# (
-#   set -x
-#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" start $create_flags
-# )
-# (
-#   set -x
-#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" start $create_flags
-# )
-# verify_ysqlsh
-# verify_ysqlsh "$custom_ip_start"
-# (
-#   set -x
-#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" destroy
-# )
-# (
-#   set -x
-#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" destroy
-# )
+log "Checking that the universes and custom ip addresses persist across restarts"
+(
+  set -x
+  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" start $create_flags
+)
+(
+  set -x
+  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" start $create_flags
+)
+verify_ysqlsh
+verify_ysqlsh "$custom_ip_start"
+(
+  set -x
+  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" destroy
+)
+(
+  set -x
+  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" destroy
+)
 
 # -------------------------------------------------------------------------------------------------
 log_heading "Testing putting this version of yb-ctl inside the installation directory"

--- a/test/yb-ctl-test.sh
+++ b/test/yb-ctl-test.sh
@@ -293,13 +293,52 @@ verify_ysqlsh 1 "$custom_ysql_port"
   "$python_interpreter" bin/yb-ctl "${yb_ctl_args[@]}" destroy
 )
 
-log_heading "Test creating multiple universes"
-data_dir_1="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-1"
-(
-  set -x
-  "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" create $create_flags
-)
-verify_ysqlsh
+# log_heading "Test creating multiple universes"
+# data_dir_1="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-1"
+# (
+#   set -x
+#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" create $create_flags
+# )
+# verify_ysqlsh
+
+# log_heading "Creating second universe with custom ip_start"
+# custom_ip_start=20
+# data_dir_2="/tmp/yb-ctl-test-data-$( date +%Y-%m-%dT%H_%M_%S )-$RANDOM-2"
+# (
+#   set -x
+#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" create $create_flags \
+#       --ip_start "$custom_ip_start"
+# )
+# verify_ysqlsh "$custom_ip_start"
+
+# (
+#   set -x
+#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" stop
+# )
+# (
+#   set -x
+#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" stop
+# )
+
+# log "Checking that the universes and custom ip addresses persist across restarts"
+# (
+#   set -x
+#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" start $create_flags
+# )
+# (
+#   set -x
+#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" start $create_flags
+# )
+# verify_ysqlsh
+# verify_ysqlsh "$custom_ip_start"
+# (
+#   set -x
+#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_1" destroy
+# )
+# (
+#   set -x
+#   "$python_interpreter" bin/yb-ctl --data_dir "$data_dir_2" destroy
+# )
 
 # -------------------------------------------------------------------------------------------------
 log_heading "Testing putting this version of yb-ctl inside the installation directory"


### PR DESCRIPTION
We currently have an odd state where flags for `yb-ctl` can only appear at odd places (e.g. `yb-ctl --rf 3 create --v`). This PR makes it so `yb-ctl` will accept flags at the end of the command (`yb-ctl create --rf 3 --v`). At a later passthrough, we should require `yb-ctl` to only accept flags at the end ([yugabyte/yugabyte-db#2440](https://github.com/yugabyte/yugabyte-db/issues/2440)).