### PR TITLE
#1845 [YSQL] Propagate cert_dir_name master flag to yb-admin in yb-ctl script

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -332,9 +332,11 @@ def remove_surrounding_quotes(s):
                 return s[1:-1]
     return s
 
+
 def flag_is_set(flags, name):
     value = flags.get(name, "").lower()
     return value == '1' or value == 'true'
+
 
 class Installer:
     YUGABYTE_DB_VERSION = '1.3.2.1'
@@ -1101,8 +1103,9 @@ class ClusterControl:
         if not self.options.placement_info:
             return
 
-        cmd = self.yb_admin_cmd_list("modify_placement_info", self.options.placement_info_raw,
-               str(self.get_replication_factor()))
+        cmd = self.yb_admin_cmd_list(
+            "modify_placement_info", self.options.placement_info_raw,
+            str(self.get_replication_factor()))
 
         def call_modify_placement_info(should_get_error):
             call_get_output_maybe_error(cmd, should_get_error)
@@ -1429,8 +1432,9 @@ class ClusterControl:
     def change_config_if_master(self, daemon_id, cmd_type):
         if daemon_id.daemon_type == DAEMON_TYPE_TSERVER:
             return
-        cmd = self.yb_admin_cmd_list("change_master_config", cmd_type, self.options.get_ip_address(daemon_id),
-               str(self.options.base_ports[DAEMON_TYPE_MASTER]["rpc"]))
+        cmd = self.yb_admin_cmd_list(
+            "change_master_config", cmd_type, self.options.get_ip_address(daemon_id),
+            str(self.options.base_ports[DAEMON_TYPE_MASTER]["rpc"]))
 
         def call_change_config(should_get_error):
             call_get_output_maybe_error(cmd, should_get_error)
@@ -1830,9 +1834,9 @@ class ClusterControl:
         print("Setting up YugaByte DB support for Redis API.")
         self.set_master_addresses()
         self.wait_for_cluster_or_raise()
-        cmd_setup_redis_table = self.yb_admin_cmd_list("--yb_num_shards_per_tserver",
-                                 str(self.options.num_shards_per_tserver),
-                                 "setup_redis_table")
+        cmd_setup_redis_table = self.yb_admin_cmd_list(
+            "--yb_num_shards_per_tserver", str(self.options.num_shards_per_tserver),
+            "setup_redis_table")
         proc = subprocess.Popen(
             cmd_setup_redis_table, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         result, _ = proc.communicate()

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -333,8 +333,8 @@ def remove_surrounding_quotes(s):
     return s
 
 
-def flag_is_set(flags, name):
-    value = flags.get(name, "").lower()
+def is_flag_true(flags, name):
+    value = flags.get(name, '').lower()
     return value == '1' or value == 'true'
 
 
@@ -1890,8 +1890,8 @@ class ClusterControl:
 
     def get_certs_dir(self):
         options = {k: v for k, v in (item.split("=") for item in self.options.master_flags)}
-        if flag_is_set(options, "use_node_to_node_encryption") \
-                and not flag_is_set(options, "allow_insecure_connections"):
+        if is_flag_true(options, "use_node_to_node_encryption") \
+                and not is_flag_true(options, "allow_insecure_connections"):
             return options.get("certs_dir")
         return None
 

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1098,10 +1098,8 @@ class ClusterControl:
         if not self.options.placement_info:
             return
 
-        yb_admin_binary_path = self.options.get_binary_path("yb-admin")
-        cmd = [yb_admin_binary_path, "--master_addresses", self.options.master_addresses,
-               "modify_placement_info", self.options.placement_info_raw,
-               str(self.get_replication_factor())]
+        cmd = self.yb_admin_cmd_list("modify_placement_info", self.options.placement_info_raw,
+               str(self.get_replication_factor()))
 
         def call_modify_placement_info(should_get_error):
             call_get_output_maybe_error(cmd, should_get_error)
@@ -1428,10 +1426,8 @@ class ClusterControl:
     def change_config_if_master(self, daemon_id, cmd_type):
         if daemon_id.daemon_type == DAEMON_TYPE_TSERVER:
             return
-        yb_admin_binary_path = self.options.get_binary_path("yb-admin")
-        cmd = [yb_admin_binary_path, "--master_addresses", self.options.master_addresses,
-               "change_master_config", cmd_type, self.options.get_ip_address(daemon_id),
-               str(self.options.base_ports[DAEMON_TYPE_MASTER]["rpc"])]
+        cmd = self.yb_admin_cmd_list("change_master_config", cmd_type, self.options.get_ip_address(daemon_id),
+               str(self.options.base_ports[DAEMON_TYPE_MASTER]["rpc"]))
 
         def call_change_config(should_get_error):
             call_get_output_maybe_error(cmd, should_get_error)
@@ -1490,13 +1486,7 @@ class ClusterControl:
         # Wait for master leader to be ready, and wait for enough tservers.
         # 'Enough' here means that the number of live tservers reported to the master should be
         # equal to the number of TS we have started -- based on directories we have on the FS.
-        yb_admin_binary_path = self.options.get_binary_path("yb-admin")
-        if not self.options.master_addresses:
-            raise ValueError("Cannot wait for cluster without knowing master addresses")
-        cmd_list_tservers = [yb_admin_binary_path,
-                             "--master_addresses",
-                             self.options.master_addresses,
-                             "list_all_tablet_servers"]
+        cmd_list_tservers = self.yb_admin_cmd_list("list_all_tablet_servers")
 
         num_alive_ts = None
         num_yb_admin_ts = None
@@ -1835,15 +1825,11 @@ class ClusterControl:
 
     def setup_redis_cmd_impl(self):
         print("Setting up YugaByte DB support for Redis API.")
-        yb_admin_binary_path = self.options.get_binary_path("yb-admin")
         self.set_master_addresses()
         self.wait_for_cluster_or_raise()
-        cmd_setup_redis_table = [yb_admin_binary_path,
-                                 "--master_addresses",
-                                 self.options.master_addresses,
-                                 "--yb_num_shards_per_tserver",
+        cmd_setup_redis_table = self.yb_admin_cmd_list("--yb_num_shards_per_tserver",
                                  str(self.options.num_shards_per_tserver),
-                                 "setup_redis_table"]
+                                 "setup_redis_table")
         proc = subprocess.Popen(
             cmd_setup_redis_table, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         result, _ = proc.communicate()
@@ -1856,9 +1842,13 @@ class ClusterControl:
         initdb_binary_path = self.options.get_binary_path("initdb")
 
         logging.info("Running initdb to initialize YSQL metadata in the YugaByte DB cluster.")
-        with SetAndRestoreEnv(
-            {'FLAGS_pggate_master_addresses': self.options.master_addresses,
-             'YB_ENABLED_IN_POSTGRES': '1'}):
+        env = {'FLAGS_pggate_master_addresses': self.options.master_addresses,
+               'YB_ENABLED_IN_POSTGRES': '1'}
+        certs_dir = self.get_certs_dir()
+        if certs_dir:
+            env.update({'FLAGS_use_client_to_server_encryption': '1',
+                        'FLAGS_certs_dir': certs_dir})
+        with SetAndRestoreEnv(env):
             adjust_env_for_ysql()
 
             tmp_pg_data_dir = os.path.join(self.args.data_dir, 'yb-ctl_tmp_pg_data_{}'.format(
@@ -1890,6 +1880,25 @@ class ClusterControl:
 
         logging.info(
             "Successfully ran initdb to initialize YSQL data in the YugaByte cluster")
+
+    def get_certs_dir(self):
+        for item in self.options.master_flags:
+            key, value = item.split("=")
+            if key == "certs_dir":
+                return value
+        return None
+
+    def yb_admin_cmd_list(self, *actions):
+        if not self.options.master_addresses:
+            raise ValueError("Cannot form yb-admin command without knowing master addresses")
+        result = [self.options.get_binary_path("yb-admin"),
+                  "--master_addresses",
+                  self.options.master_addresses]
+        certs_dir = self.get_certs_dir()
+        if certs_dir:
+            result.extend(("--certs_dir_name", certs_dir))
+        result.extend(actions)
+        return result
 
     # ---------------------------------------------------------------------------------------------
     # The "main" function of the ClusterControl class

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -332,6 +332,9 @@ def remove_surrounding_quotes(s):
                 return s[1:-1]
     return s
 
+def flag_is_set(flags, name):
+    value = flags.get(name, "").lower()
+    return value == '1' or value == 'true'
 
 class Installer:
     YUGABYTE_DB_VERSION = '1.3.2.1'
@@ -1882,10 +1885,10 @@ class ClusterControl:
             "Successfully ran initdb to initialize YSQL data in the YugaByte cluster")
 
     def get_certs_dir(self):
-        for item in self.options.master_flags:
-            key, value = item.split("=")
-            if key == "certs_dir":
-                return value
+        options = {k: v for k, v in (item.split("=") for item in self.options.master_flags)}
+        if flag_is_set(options, "use_node_to_node_encryption") \
+                and not flag_is_set(options, "allow_insecure_connections"):
+            return options.get("certs_dir")
         return None
 
     def yb_admin_cmd_list(self, *actions):


### PR DESCRIPTION
In case of starting new cluster with TLS by using command like:
```
./bin/yb-ctl start --master_flags "use_node_to_node_encryption=true,allow_insecure_connections=false,certs_dir=<cert_dir>" --tserver_flags "use_client_to_server_encryption=true,use_node_to_node_encryption=true,allow_insecure_connections=false,certs_dir=<cert_dir>"
```

`yb-admin` will try to access master and it should use encrypted connection if insecure connections are disallowed. For this purpose `certs_dir` argument should be forwarded to `yb-admin` 