### PR TITLE
#2980 [YSQL] Use default value for certs_dir in yb-ctl when needed

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1892,7 +1892,9 @@ class ClusterControl:
         options = {k: v for k, v in (item.split("=") for item in self.options.master_flags)}
         if is_flag_true(options, "use_node_to_node_encryption") \
                 and not is_flag_true(options, "allow_insecure_connections"):
-            return options.get("certs_dir")
+            return options.get(
+                "certs_dir",
+                "{}/yb-data/{}/certs".format(self.get_base_node_dirs(1)[0], DAEMON_TYPE_MASTER))
         return None
 
     def yb_admin_cmd_list(self, *actions):


### PR DESCRIPTION
`t-server` and `master` have default value for certificate folder so user may not specify them explicitly.
`yb-ctl` should use same default value.