### PR TITLE
Fix a bug with args

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -711,8 +711,7 @@ class ClusterOptions:
 
         # -----------------------------------------------------------------------------------------
         # Automatic YugaByte DB installation
-        # -----------------------------------------------------------------------------------------
-        
+        # -----------------------------------------------------------------------------------------  
         if args.install_if_needed and not self.installation_dir:
             installer = Installer()
             if installer.install_or_find_existing():

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -712,8 +712,7 @@ class ClusterOptions:
         # -----------------------------------------------------------------------------------------
         # Automatic YugaByte DB installation
         # -----------------------------------------------------------------------------------------
-
-        if args.install_if_needed and not self.installation_dir:
+        if args.install_dest and not self.installation_dir:
             installer = Installer()
             if installer.install_or_find_existing():
                 self.installation_dir = installer.installation_dir

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -712,6 +712,7 @@ class ClusterOptions:
         # -----------------------------------------------------------------------------------------
         # Automatic YugaByte DB installation
         # -----------------------------------------------------------------------------------------
+        
         if args.install_if_needed and not self.installation_dir:
             installer = Installer()
             if installer.install_or_find_existing():

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -711,7 +711,7 @@ class ClusterOptions:
 
         # -----------------------------------------------------------------------------------------
         # Automatic YugaByte DB installation
-        # -----------------------------------------------------------------------------------------  
+        # -----------------------------------------------------------------------------------------
         if args.install_if_needed and not self.installation_dir:
             installer = Installer()
             if installer.install_or_find_existing():

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -712,7 +712,7 @@ class ClusterOptions:
         # -----------------------------------------------------------------------------------------
         # Automatic YugaByte DB installation
         # -----------------------------------------------------------------------------------------
-        if args.install_dest and not self.installation_dir:
+        if args.install_if_needed and not self.installation_dir:
             installer = Installer()
             if installer.install_or_find_existing():
                 self.installation_dir = installer.installation_dir
@@ -820,7 +820,8 @@ class ClusterControl:
         self.parent_parser = argparse.ArgumentParser(add_help=False)
         self.setup_parent_parser()
         self.parser = argparse.ArgumentParser()
-        self.subparsers = self.parser.add_subparsers()
+        self.subparsers = self.parser.add_subparsers(dest='command')
+        self.subparsers.required = True
 
         # This is a dictionary serialized into JSON and written to a configuration file in the data
         # directory.


### PR DESCRIPTION
Tried running the yb-ctl without any args and it errored, this fixes that issue.

Tested by `yb-ctl`

The error is due to the change in argparse behavior from 2 to 3.
https://stackoverflow.com/questions/22990977/why-does-this-argparse-code-behave-differently-between-python-2-and-3

Error message looks like

```
17:08 $ python3 bin/yb-ctl
Traceback (most recent call last):
  File "bin/yb-ctl", line 1969, in <module>
    control.run()
  File "bin/yb-ctl", line 1943, in run
    fallback_installation_dir=self.cluster_config.get("installation_dir"))
  File "bin/yb-ctl", line 716, in update_options_from_args
    if args.install_if_needed and not self.installation_dir:
AttributeError: 'Namespace' object has no attribute 'install_if_needed'
Viewing file /tmp/tmp8md0ltph:
^^^ Encountered errors ^^^
```