### PR TITLE
Fixed get_certs_dir in yb-ctl (yugabyte/yugabyte-db#4234)

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1923,6 +1923,9 @@ class ClusterControl:
             "Successfully ran initdb to initialize YSQL data in the YugaByte cluster")
 
     def get_certs_dir(self):
+        # We split parameters containing multiple '='s like 'vmodule=meta_cache=5,tablet=5' into 
+        # key before first '=' and value for the rest by passing maxsplit = 1 into item.split as
+        # a second parameter.
         options = {k: v for k, v in (item.split("=", 1) for item in self.options.master_flags)}
         if is_flag_true(options, "use_node_to_node_encryption") \
                 and not is_flag_true(options, "allow_insecure_connections"):

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1923,7 +1923,7 @@ class ClusterControl:
             "Successfully ran initdb to initialize YSQL data in the YugaByte cluster")
 
     def get_certs_dir(self):
-        options = {k: v for k, v in (item.split("=") for item in self.options.master_flags)}
+        options = {k: v for k, v in (item.split("=", 1) for item in self.options.master_flags)}
         if is_flag_true(options, "use_node_to_node_encryption") \
                 and not is_flag_true(options, "allow_insecure_connections"):
             return options.get(

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1923,7 +1923,7 @@ class ClusterControl:
             "Successfully ran initdb to initialize YSQL data in the YugaByte cluster")
 
     def get_certs_dir(self):
-        # We split parameters containing multiple '='s like 'vmodule=meta_cache=5,tablet=5' into 
+        # We split parameters containing multiple '='s like 'vmodule=meta_cache=5,tablet=5' into
         # key before first '=' and value for the rest by passing maxsplit = 1 into item.split as
         # a second parameter.
         options = {k: v for k, v in (item.split("=", 1) for item in self.options.master_flags)}


### PR DESCRIPTION
https://github.com/yugabyte/yugabyte-db/issues/4234

The fix is to split parameters containing multiple `=` like `vmodule=meta_cache=5,tablet=5` into key before first `=` and value for the rest.