### PR TITLE
[#4139] Increase default mem limit allowed for master

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -546,6 +546,8 @@ class ClusterOptions:
         self.ysql_num_shards_per_tserver = None
         self.timeout_yb_admin_sec = None
         self.timeout_processes_running_sec = None
+        self.master_memory_limit_ratio = 0.35
+        self.tserver_memory_limit_ratio = 0.65
 
         self.cluster_base_dir = None
 
@@ -632,6 +634,10 @@ class ClusterOptions:
         self.ysql_num_shards_per_tserver = args.ysql_num_shards_per_tserver
         self.timeout_yb_admin_sec = args.timeout_yb_admin_sec
         self.timeout_processes_running_sec = args.timeout_processes_running_sec
+        if hasattr(args, "master_memory_limit_ratio"):
+            self.master_memory_limit_ratio = args.master_memory_limit_ratio
+        if hasattr(args, "tserver_memory_limit_ratio"):
+            self.tserver_memory_limit_ratio = args.tserver_memory_limit_ratio
 
         if hasattr(args, "v"):
             self.verbose_level = args.v
@@ -1075,6 +1081,12 @@ class ClusterControl:
                                          "Note --verbose affects yb-ctl and --v affects server "
                                          "processes. Default is 0 and maximum is 4.")
 
+            subparsers[cmd].add_argument("--tserver_memory_limit_ratio", default=0.65, type=float,
+                                        help="Ratio of total memory that tserver will be restricted to.")
+
+            subparsers[cmd].add_argument("--master_memory_limit_ratio", default=0.35, type=float,
+                                        help="Ratio of total memory that master will be restricted to.")
+
             subparsers[cmd].add_argument("--use_cassandra_authentication",
                                          action='store_true',
                                          help="If specified, this flag will be "
@@ -1281,7 +1293,8 @@ class ClusterControl:
         command_list = [
             "--replication_factor={}".format(self.get_replication_factor()),
             "--yb_num_shards_per_tserver {}".format(self.options.num_shards_per_tserver),
-            "--ysql_num_shards_per_tserver={}".format(self.options.ysql_num_shards_per_tserver)
+            "--ysql_num_shards_per_tserver={}".format(self.options.ysql_num_shards_per_tserver),
+            "--default_memory_limit_to_ram_ratio={}".format(self.options.master_memory_limit_ratio)
         ]
 
         if not self.options.is_shell_master:
@@ -1308,7 +1321,8 @@ class ClusterControl:
             # TODO ENG-2876: Enable this in master as well.
             "--use_cassandra_authentication={}".format(
                 str(self.options.use_cassandra_authentication).lower()),
-            "--ysql_num_shards_per_tserver={}".format(self.options.ysql_num_shards_per_tserver)
+            "--ysql_num_shards_per_tserver={}".format(self.options.ysql_num_shards_per_tserver),
+            "--default_memory_limit_to_ram_ratio={}".format(self.options.tserver_memory_limit_ratio)
         ]
         if self.is_ysql_enabled():
             command_list += [


### PR DESCRIPTION
https://github.com/YugaByte/yugabyte-db/issues/4139

https://github.com/YugaByte/yugabyte-db/issues/3742

Without these flags create database fails on low mem nodes (<= 4GB)

https://github.com/yugabyte/yugabyte-db/commit/c685bc41ee5993a14531e022267c1a1881422110 has more details

Test Plan:
```
sanketh@Sankeths-MacBook-Pro ~/code/yugabyte-installation master$ bin/yb-ctl destroy && bin/yb-ctl start --rf 1 --master_memory_limit_ratio=0.85 --tserver_memory_limit_ratio=0.95; pgrep -laf yb-
Destroying cluster.
Creating cluster.
Waiting for cluster to be ready.
----------------------------------------------------------------------------------------------------
| Node Count: 1 | Replication Factor: 1                                                            |
----------------------------------------------------------------------------------------------------
| JDBC                : jdbc:postgresql://127.0.0.1:5433/postgres                                  |
| YSQL Shell          : ../yugabyte/build/latest/bin/ysqlsh                                        |
| YCQL Shell          : ../yugabyte/build/latest/bin/cqlsh                                         |
| YEDIS Shell         : ../yugabyte/build/latest/bin/redis-cli                                     |
| Web UI              : http://127.0.0.1:7000/                                                     |
| Cluster Data        : /Users/sanketh/yugabyte-data                                               |
----------------------------------------------------------------------------------------------------

For more info, please use: yb-ctl status
86170 less /tmp/xyz2/yb-data/master/logs/yb-master.INFO
92266 /Users/sanketh/code/yugabyte/build/latest/bin/yb-master --fs_data_dirs /Users/sanketh/yugabyte-data/node-1/disk-1 --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/sanketh/code/yugabyte-db/build/debug-clang-dynamic-ninja --callhome_enabled=false --replication_factor=1 --yb_num_shards_per_tserver 2 --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.85 --master_addresses 127.0.0.1:7100 --enable_ysql=true
92269 /Users/sanketh/code/yugabyte/build/latest/bin/yb-tserver --fs_data_dirs /Users/sanketh/yugabyte-data/node-1/disk-1 --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/sanketh/code/yugabyte-db/build/debug-clang-dynamic-ninja --callhome_enabled=false --tserver_master_addrs=127.0.0.1:7100 --yb_num_shards_per_tserver=2 --redis_proxy_bind_address=127.0.0.1:6379 --cql_proxy_bind_address=127.0.0.1:9042 --local_ip_for_outbound_sockets=127.0.0.1 --use_cassandra_authentication=false --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.95 --enable_ysql=true --pgsql_proxy_bind_address=127.0.0.1:5433
92283 /Users/sanketh/code/yugabyte/build/latest/postgres/bin/postgres -D /Users/sanketh/yugabyte-data/node-1/disk-1/pg_data -p 5433 -h 127.0.0.1 -k -c logging_collector=on -c log_directory=/Users/sanketh/yugabyte-data/node-1/disk-1/yb-data/tserver/logs -c shared_preload_libraries=pg_stat_statements,yb_pg_metrics -c yb_pg_metrics.node_name=DEFAULT_NODE_NAME -c yb_pg_metrics.port=13000 -c config_file=/Users/sanketh/yugabyte-data/node-1/disk-1/pg_data/ysql_pg.conf -c hba_file=/Users/sanketh/yugabyte-data/node-1/disk-1/pg_data/ysql_hba.conf TERM_PROGRAM=iTerm.app
sanketh@Sankeths-MacBook-Pro ~/code/yugabyte-installation master$ bin/yb-ctl destroy && bin/yb-ctl start --rf 1 ; pgrep -laf yb-
Destroying cluster.
Creating cluster.
Waiting for cluster to be ready.
----------------------------------------------------------------------------------------------------
| Node Count: 1 | Replication Factor: 1                                                            |
----------------------------------------------------------------------------------------------------
| JDBC                : jdbc:postgresql://127.0.0.1:5433/postgres                                  |
| YSQL Shell          : ../yugabyte/build/latest/bin/ysqlsh                                        |
| YCQL Shell          : ../yugabyte/build/latest/bin/cqlsh                                         |
| YEDIS Shell         : ../yugabyte/build/latest/bin/redis-cli                                     |
| Web UI              : http://127.0.0.1:7000/                                                     |
| Cluster Data        : /Users/sanketh/yugabyte-data                                               |
----------------------------------------------------------------------------------------------------

For more info, please use: yb-ctl status
86170 less /tmp/xyz2/yb-data/master/logs/yb-master.INFO
92316 /Users/sanketh/code/yugabyte/build/latest/bin/yb-master --fs_data_dirs /Users/sanketh/yugabyte-data/node-1/disk-1 --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/sanketh/code/yugabyte-db/build/debug-clang-dynamic-ninja --callhome_enabled=false --replication_factor=1 --yb_num_shards_per_tserver 2 --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.35 --master_addresses 127.0.0.1:7100 --enable_ysql=true
92319 /Users/sanketh/code/yugabyte/build/latest/bin/yb-tserver --fs_data_dirs /Users/sanketh/yugabyte-data/node-1/disk-1 --webserver_interface 127.0.0.1 --rpc_bind_addresses 127.0.0.1 --v 0 --version_file_json_path=/Users/sanketh/code/yugabyte-db/build/debug-clang-dynamic-ninja --callhome_enabled=false --tserver_master_addrs=127.0.0.1:7100 --yb_num_shards_per_tserver=2 --redis_proxy_bind_address=127.0.0.1:6379 --cql_proxy_bind_address=127.0.0.1:9042 --local_ip_for_outbound_sockets=127.0.0.1 --use_cassandra_authentication=false --ysql_num_shards_per_tserver=2 --default_memory_limit_to_ram_ratio=0.65 --enable_ysql=true --pgsql_proxy_bind_address=127.0.0.1:5433
92333 /Users/sanketh/code/yugabyte/build/latest/postgres/bin/postgres -D /Users/sanketh/yugabyte-data/node-1/disk-1/pg_data -p 5433 -h 127.0.0.1 -k -c logging_collector=on -c log_directory=/Users/sanketh/yugabyte-data/node-1/disk-1/yb-data/tserver/logs -c shared_preload_libraries=pg_stat_statements,yb_pg_metrics -c yb_pg_metrics.node_name=DEFAULT_NODE_NAME -c yb_pg_metrics.port=13000 -c config_file=/Users/sanketh/yugabyte-data/node-1/disk-1/pg_data/ysql_pg.conf -c hba_file=/Users/sanketh/yugabyte-data/node-1/disk-1/pg_data/ysql_hba.conf TERM_PROGRAM=iTerm.app
```