### PR TITLE
[#4566] yb-ctl listen_ip should default to 0.0.0.0 for rf 1

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -649,11 +649,8 @@ class ClusterOptions:
             self.ip_start = args.ip_start
 
         if hasattr(args, "listen_ip"):
-            if args.listen_ip:
-                print("listen_ip PROVIDED")
-                self.listen_ip = args.listen_ip
-            elif (self.replication_factor == 1):
-                print("Not set and RF 1 so default.")
+            self.listen_ip = args.listen_ip
+            if (self.replication_factor == 1 and not self.listen_ip):
                 self.listen_ip = '0.0.0.0'
             if self.listen_ip and self.replication_factor > 1:
                 raise RuntimeError("Invalid argument: listen_ip is only compatible with rf=1")

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -649,7 +649,12 @@ class ClusterOptions:
             self.ip_start = args.ip_start
 
         if hasattr(args, "listen_ip"):
-            self.listen_ip = args.listen_ip
+            if args.listen_ip:
+                print("listen_ip PROVIDED")
+                self.listen_ip = args.listen_ip
+            elif (self.replication_factor == 1):
+                print("Not set and RF 1 so default.")
+                self.listen_ip = '0.0.0.0'
             if self.listen_ip and self.replication_factor > 1:
                 raise RuntimeError("Invalid argument: listen_ip is only compatible with rf=1")
 
@@ -799,7 +804,9 @@ class ClusterOptions:
         return "{}:{}".format(base_local_url, self.get_port_str(daemon_id, port_type))
 
     def get_client_listen_host_port(self, daemon_id, port_type=None):
+        print("LISTEN listen_ip is %s" % self.listen_ip)
         base_local_url = self.listen_ip if self.listen_ip else self.get_ip_address(daemon_id)
+        print("After logic, base_local_url is %s" % base_local_url)
         if port_type is None:
             return base_local_url
         else:
@@ -807,8 +814,10 @@ class ClusterOptions:
 
     def get_client_advertise_host_port(self, daemon_id, port_type=None):
         base_ip = self.get_ip_address(daemon_id)
+        print("Initial base ip %s" % base_ip)
         if self.listen_ip and self.listen_ip != "0.0.0.0":
             base_ip = self.listen_ip
+        print("After if base ip %s" % base_ip)
         if port_type is None:
             return base_ip
         else:

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -801,9 +801,7 @@ class ClusterOptions:
         return "{}:{}".format(base_local_url, self.get_port_str(daemon_id, port_type))
 
     def get_client_listen_host_port(self, daemon_id, port_type=None):
-        print("LISTEN listen_ip is %s" % self.listen_ip)
         base_local_url = self.listen_ip if self.listen_ip else self.get_ip_address(daemon_id)
-        print("After logic, base_local_url is %s" % base_local_url)
         if port_type is None:
             return base_local_url
         else:
@@ -811,10 +809,8 @@ class ClusterOptions:
 
     def get_client_advertise_host_port(self, daemon_id, port_type=None):
         base_ip = self.get_ip_address(daemon_id)
-        print("Initial base ip %s" % base_ip)
         if self.listen_ip and self.listen_ip != "0.0.0.0":
             base_ip = self.listen_ip
-        print("After if base ip %s" % base_ip)
         if port_type is None:
             return base_ip
         else:


### PR DESCRIPTION
**Summary**: The default listen_ip address should be 0.0.0.0 whenever the rf = 1. Existing functionality is not changed (listen_ip is still only valid for rf = 1) and different listen_ip addresses other than 0.0.0.0 can be specified, but in the default cases listen_ip defaults to 0.0.0.0. 

**Test Plan**: Run in different cases with RF > 1 or = 1 and listen_ip unspecified or specified to a particular IP. Consistency between old and new was verified by checking values of listen_ip in all locations where it's used throughout yb-ctl (only 2, afaik). The command sudo lsof -PiTCP -sTCP:LISTEN | egrep yb- (mac, "netstat -tlnp | egrep yb-" for linux) was used to verify that the listen_ip was modified between versions as intended.


```
15:33 ~/yugabyte-2.1.6.0/bin $ ./my-yb-ctl create
Creating cluster.
Waiting for cluster to be ready.
----------------------------------------------------------------------------------------------------
| Node Count: 1 | Replication Factor: 1                                                            |
----------------------------------------------------------------------------------------------------
| JDBC                : jdbc:postgresql://127.0.0.1:5433/postgres                                  |
| YSQL Shell          : ysqlsh                                                                     |
| YCQL Shell          : cqlsh                                                                      |
| YEDIS Shell         : redis-cli                                                                  |
| Web UI              : http://127.0.0.1:7000/                                                     |
| Cluster Data        : /Users/muthu/yugabyte-data                                                 |
----------------------------------------------------------------------------------------------------

For more info, please use: yb-ctl status
15:35 ~/yugabyte-2.1.6.0/bin $ sudo lsof -PiTCP -sTCP:LISTEN | egrep yb-
Password:
yb-master 5274  muthu   65u  IPv4 0x5fefadc1a15d8d19      0t0  TCP localhost:7100 (LISTEN)
yb-master 5274  muthu   66u  IPv4 0x5fefadc1a15d7959      0t0  TCP *:7000 (LISTEN)
yb-tserve 5277  muthu   49u  IPv4 0x5fefadc1a15d5bb9      0t0  TCP localhost:9100 (LISTEN)
yb-tserve 5277  muthu   50u  IPv4 0x5fefadc1a15d51d9      0t0  TCP *:9000 (LISTEN)
yb-tserve 5277  muthu  101u  IPv4 0x5fefadc1a19d3d19      0t0  TCP *:6379 (LISTEN)
yb-tserve 5277  muthu  107u  IPv4 0x5fefadc1a19297f9      0t0  TCP *:11000 (LISTEN)
yb-tserve 5277  muthu  155u  IPv4 0x5fefadc1a192d339      0t0  TCP *:9042 (LISTEN)
yb-tserve 5277  muthu  156u  IPv4 0x5fefadc1a192b599      0t0  TCP *:12000 (LISTEN)
15:36 ~/yugabyte-2.1.6.0/bin 




15:40 ~/yugabyte-2.1.6.0/bin $ ./my-yb-ctl create --listen_ip 127.0.0.4
Creating cluster.
Waiting for cluster to be ready.
...........................................................
----------------------------------------------------------------------------------------------------
| Node Count: 1 | Replication Factor: 1                                                            |
----------------------------------------------------------------------------------------------------
| JDBC                : jdbc:postgresql://127.0.0.4:5433/postgres                                  |
| YSQL Shell          : ysqlsh -h 127.0.0.4                                                        |
| YCQL Shell          : cqlsh 127.0.0.4                                                            |
| YEDIS Shell         : redis-cli -h 127.0.0.4                                                     |
| Web UI              : http://127.0.0.4:7000/                                                     |
| Cluster Data        : /Users/muthu/yugabyte-data                                                 |
----------------------------------------------------------------------------------------------------

For more info, please use: yb-ctl status
15:42 ~/yugabyte-2.1.6.0/bin $ sudo lsof -PiTCP -sTCP:LISTEN | egrep yb-
yb-master 5549  muthu   65u  IPv4 0x5fefadc1a53421d9      0t0  TCP localhost:7100 (LISTEN)
yb-master 5549  muthu   66u  IPv4 0x5fefadc1a53417f9      0t0  TCP 127.0.0.4:7000 (LISTEN)
yb-tserve 5552  muthu   49u  IPv4 0x5fefadc1a1abcd19      0t0  TCP localhost:9100 (LISTEN)
yb-tserve 5552  muthu   50u  IPv4 0x5fefadc1a1ab91d9      0t0  TCP 127.0.0.4:9000 (LISTEN)
yb-tserve 5552  muthu  114u  IPv4 0x5fefadc1a0d867f9      0t0  TCP 127.0.0.4:6379 (LISTEN)
yb-tserve 5552  muthu  117u  IPv4 0x5fefadc19eb74f79      0t0  TCP 127.0.0.4:11000 (LISTEN)
yb-tserve 5552  muthu  165u  IPv4 0x5fefadc19473f7f9      0t0  TCP 127.0.0.4:9042 (LISTEN)
yb-tserve 5552  muthu  166u  IPv4 0x5fefadc1a544a7f9      0t0  TCP 127.0.0.4:12000 (LISTEN)



15:37 ~/yugabyte-2.1.6.0/bin $ ./my-yb-ctl create --rf 3
Creating cluster.
Waiting for cluster to be ready.
...........................................................
----------------------------------------------------------------------------------------------------
| Node Count: 3 | Replication Factor: 3                                                            |
----------------------------------------------------------------------------------------------------
| JDBC                : jdbc:postgresql://127.0.0.1:5433/postgres                                  |
| YSQL Shell          : ysqlsh                                                                     |
| YCQL Shell          : cqlsh                                                                      |
| YEDIS Shell         : redis-cli                                                                  |
| Web UI              : http://127.0.0.1:7000/                                                     |
| Cluster Data        : /Users/muthu/yugabyte-data                                                 |
----------------------------------------------------------------------------------------------------

For more info, please use: yb-ctl status
15:39 ~/yugabyte-2.1.6.0/bin $ sudo lsof -PiTCP -sTCP:LISTEN | egrep yb-
yb-master 5433  muthu   65u  IPv4 0x5fefadc1a5335bb9      0t0  TCP localhost:7100 (LISTEN)
yb-master 5433  muthu   67u  IPv4 0x5fefadc1a1b0e1d9      0t0  TCP localhost:7000 (LISTEN)
yb-master 5436  muthu   65u  IPv4 0x5fefadc1a19d3d19      0t0  TCP 127.0.0.2:7100 (LISTEN)
yb-master 5436  muthu   67u  IPv4 0x5fefadc1a5521599      0t0  TCP 127.0.0.2:7000 (LISTEN)
yb-master 5439  muthu   65u  IPv4 0x5fefadc1a5336599      0t0  TCP 127.0.0.3:7100 (LISTEN)
yb-master 5439  muthu   68u  IPv4 0x5fefadc1a53351d9      0t0  TCP 127.0.0.3:7000 (LISTEN)
yb-tserve 5442  muthu   49u  IPv4 0x5fefadc19baf2d19      0t0  TCP localhost:9100 (LISTEN)
yb-tserve 5442  muthu   53u  IPv4 0x5fefadc18f3e6339      0t0  TCP localhost:9000 (LISTEN)
yb-tserve 5442  muthu  146u  IPv4 0x5fefadc1a53f2959      0t0  TCP localhost:6379 (LISTEN)
yb-tserve 5442  muthu  147u  IPv4 0x5fefadc1a5523d19      0t0  TCP localhost:11000 (LISTEN)
yb-tserve 5442  muthu  195u  IPv4 0x5fefadc1a1b0f599      0t0  TCP localhost:9042 (LISTEN)
yb-tserve 5442  muthu  196u  IPv4 0x5fefadc1a192abb9      0t0  TCP localhost:12000 (LISTEN)
yb-tserve 5445  muthu   49u  IPv4 0x5fefadc1a5489d19      0t0  TCP 127.0.0.2:9100 (LISTEN)
yb-tserve 5445  muthu   53u  IPv4 0x5fefadc19bd6d1d9      0t0  TCP 127.0.0.2:9000 (LISTEN)
yb-tserve 5445  muthu  146u  IPv4 0x5fefadc1a0366599      0t0  TCP 127.0.0.2:6379 (LISTEN)
yb-tserve 5445  muthu  147u  IPv4 0x5fefadc1a5521f79      0t0  TCP 127.0.0.2:11000 (LISTEN)
yb-tserve 5445  muthu  195u  IPv4 0x5fefadc1a00d7959      0t0  TCP 127.0.0.2:9042 (LISTEN)
yb-tserve 5445  muthu  196u  IPv4 0x5fefadc1a192b599      0t0  TCP 127.0.0.2:12000 (LISTEN)
yb-tserve 5448  muthu   49u  IPv4 0x5fefadc194740bb9      0t0  TCP 127.0.0.3:9100 (LISTEN)
yb-tserve 5448  muthu   52u  IPv4 0x5fefadc19eb76d19      0t0  TCP 127.0.0.3:9000 (LISTEN)
yb-tserve 5448  muthu  146u  IPv4 0x5fefadc1a0f08339      0t0  TCP 127.0.0.3:6379 (LISTEN)
yb-tserve 5448  muthu  147u  IPv4 0x5fefadc1a0368d19      0t0  TCP 127.0.0.3:11000 (LISTEN)
yb-tserve 5448  muthu  195u  IPv4 0x5fefadc1a15d51d9      0t0  TCP 127.0.0.3:9042 (LISTEN)
yb-tserve 5448  muthu  196u  IPv4 0x5fefadc1a5343599      0t0  TCP 127.0.0.3:12000 (LISTEN)


15:43 ~/yugabyte-2.1.6.0/bin $ ./my-yb-ctl create --listen_ip 0.0.0.0  --rf 3
Traceback (most recent call last):
  File "./my-yb-ctl", line 2023, in <module>
    control.run()
  File "./my-yb-ctl", line 1997, in run
    fallback_installation_dir=self.cluster_config.get("installation_dir"))
  File "./my-yb-ctl", line 656, in update_options_from_args
    raise RuntimeError("Invalid argument: listen_ip is only compatible with rf=1")
RuntimeError: Invalid argument: listen_ip is only compatible with rf=1
Viewing file /var/folders/wp/6cvs8scs27z206hzc5vrx1mw0000gn/T/tmpgYVdNB:
^^^ Encountered errors ^^^
```