### PR TITLE
yb-ctl: avoid listen_ip default overriding ip_start

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -648,7 +648,8 @@ class ClusterOptions:
         if hasattr(args, "ip_start"):
             self.ip_start = args.ip_start
 
-        if hasattr(args, "listen_ip"):
+        # Don't set listen_ip when ip_start is given.
+        if hasattr(args, "listen_ip") and args.ip_start is None:
             self.listen_ip = args.listen_ip
             if (self.replication_factor == 1 and not self.listen_ip):
                 self.listen_ip = '0.0.0.0'

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1125,7 +1125,7 @@ class ClusterControl:
                 help="We create separate directories and treat them as separate drives.")
 
             subparsers[cmd].add_argument(
-                "--ip_start", default=DEFAULT_IP_START, type=int,
+                "--ip_start", type=int,
                 help="Start index for IP address")
 
             subparsers[cmd].add_argument(

--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -646,15 +646,15 @@ class ClusterOptions:
             self.use_cassandra_authentication = args.use_cassandra_authentication
 
         if hasattr(args, "ip_start"):
-            self.ip_start = args.ip_start
-
-        # Don't set listen_ip when ip_start is given.
-        if hasattr(args, "listen_ip") and args.ip_start is None:
-            self.listen_ip = args.listen_ip
-            if (self.replication_factor == 1 and not self.listen_ip):
-                self.listen_ip = '0.0.0.0'
-            if self.listen_ip and self.replication_factor > 1:
-                raise RuntimeError("Invalid argument: listen_ip is only compatible with rf=1")
+            if args.ip_start is not None:
+                self.ip_start = args.ip_start
+            elif hasattr(args, "listen_ip"):
+                # Only set listen_ip if ip_start is not given.
+                self.listen_ip = args.listen_ip
+                if (self.replication_factor == 1 and not self.listen_ip):
+                    self.listen_ip = '0.0.0.0'
+                if self.listen_ip and self.replication_factor > 1:
+                    raise RuntimeError("Invalid argument: listen_ip is only compatible with rf=1")
 
         for arg in ["master_flags", "tserver_flags"]:
             try:


### PR DESCRIPTION

`--ip_start` specifies the ip addresses to use for addresses like
`rpc_bind_address` and `pgsql_proxy_bind_address`.  For example,
`--ip_start 7` with `--rf 3` will create masters and tservers each with
addresses `127.0.0.7`, `127.0.0.8`, and `127.0.0.9`.

`--listen_ip` specifies the ip address to use for listen addresses like
`pgsql_proxy_bind_address`.

When `--listen_ip` is not given, it takes on a default value of
`0.0.0.0` (for rf 1).  This is a recent feature from commit
69e8b995ef5880ac84198df25cea3d379ef15075 ([#4566] yb-ctl listen_ip
should default to 0.0.0.0 for rf 1 (#32)).  The problem is when
`--ip_start` is given but `--listen_ip` is not given: it still sets the
default value for `ClusterOptions.listen_ip` and makes things like
`pgsql_proxy_bind_address` use `0.0.0.0`.  Restore the old behavior by
**not** setting `ClusterOptions.listen_ip` to `0.0.0.0` in that case.

Close: yugabyte/yugabyte-db#4648