### PR TITLE
Changed JDBC URL to use yugabyte as default database.

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1647,7 +1647,7 @@ class ClusterControl:
                 YSQL_DEFAULT_PORT)
 
             info_kv_list.extend([
-                ("JDBC", "jdbc:postgresql://{}:{}/postgres".format(
+                ("JDBC", "jdbc:postgresql://{}:{}/yugabyte".format(
                     ip_address, ysql_port)),
                 ("YSQL Shell", ysqlsh_cmd_line)
             ])


### PR DESCRIPTION
Changed JDBC URL in yb-ctl status to use `yugabyte` instead of `postgres` as the default database. This was committed in the yugabyte-db repo here - https://github.com/yugabyte/yugabyte-db/commit/ec5d86d57cd5637da77971af34d0da3848dc7f82 - and references the following issue - https://github.com/yugabyte/yugabyte-db/issues/4997. 

This needs to be included in the 2.2 release. 2.2 does not include the movement of `yb-ctl` from `yugabyte-installation` to the main `yugabyte-db` repository.

After this change, I will cherry pick a submodule update onto the 2.2 branch of `yugabyte-db`.
