### PR TITLE
yb-ctl breaks in Python 3.7+ because os.errno is no longer available

### DIFF
--- a/bin/yb-ctl
+++ b/bin/yb-ctl
@@ -1393,7 +1393,7 @@ class ClusterControl:
         try:
             os.kill(pid, signal.SIGTERM)
         except OSError as e:
-            if e.errno == os.errno.ESRCH:
+            if e.errno == errno.ESRCH:
                 logging.info("{} does not exist; nothing to stop".format(name))
             else:
                 raise e


### PR DESCRIPTION
Fix described in https://github.com/yugabyte/yugabyte-db/issues/5118

```
$ python3.7
Python 3.7.8 (default, Jun 29 2020, 05:44:46) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.errno
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'os' has no attribute 'errno'
```